### PR TITLE
cli.sh works directory independent

### DIFF
--- a/scripts/cosm/cli.sh
+++ b/scripts/cosm/cli.sh
@@ -6,16 +6,15 @@ command -v shellcheck > /dev/null && shellcheck "$0"
 REPOSITORY="cosmwasm/wasmd"
 VERSION="manual"
 
-CURRENT_DIR="$(realpath "$(dirname "$0")")"
 BLOCKCHAIN_CONTAINER_NAME="wasmd"
-HOME_DIR="/home"
+
+# TODO: make this run as UID? Does this matter?
+HOME_DIR="/root"
 
 docker run \
   --rm \
-  --user="$UID" \
   -it \
-  -v "$CURRENT_DIR/.gaiad:$HOME_DIR/.gaiad" \
-  -v "$CURRENT_DIR/.gaiacli:$HOME_DIR/.gaiacli" \
+  --mount type=volume,source=wasmcli_data,target=/root/.wasmcli \
   -w "$HOME_DIR" \
   --env "HOME=$HOME_DIR" \
   --net "container:$BLOCKCHAIN_CONTAINER_NAME" \


### PR DESCRIPTION
Follow up on https://github.com/confio/cosm-js/pull/2#pullrequestreview-347229803

This runs properly as root and makes https://github.com/cosmwasm/wasmd/issues/43 less important (do we want to fix it anyway?)

Tested:

```sh
./scripts/cosm/cli.sh keys list
./scripts/cosm/cli.sh keys add foobar
./scripts/cosm/cli.sh keys list
cd scripts/cosm
./cli.sh keys list
```

`./cli.sh status` also works, showing it does connect to the running server (good job with `--net`, that is kinda magic to me)
