### PR TITLE
Normalize unset attribute value to empty string

### DIFF
--- a/packages/sdk/src/logs.spec.ts
+++ b/packages/sdk/src/logs.spec.ts
@@ -8,9 +8,14 @@ describe("logs", () => {
       expect(attr).toEqual({ key: "a", value: "b" });
     });
 
-    it("works for unset value", () => {
+    it("works for empty value", () => {
+      const attr = parseAttribute({ key: "foobar", value: "" });
+      expect(attr).toEqual({ key: "foobar", value: "" });
+    });
+
+    it("normalized unset value to empty string", () => {
       const attr = parseAttribute({ key: "amount" });
-      expect(attr).toEqual({ key: "amount", value: undefined });
+      expect(attr).toEqual({ key: "amount", value: "" });
     });
   });
 
@@ -68,7 +73,7 @@ describe("logs", () => {
           },
           {
             key: "amount",
-            value: undefined,
+            value: "",
           },
         ],
       } as const;

--- a/packages/sdk/src/logs.ts
+++ b/packages/sdk/src/logs.ts
@@ -3,7 +3,7 @@ import { isNonNullObject } from "@iov/encoding";
 
 export interface Attribute {
   readonly key: string;
-  readonly value: string | undefined;
+  readonly value: string;
 }
 
 export interface Event {
@@ -27,7 +27,7 @@ export function parseAttribute(input: unknown): Attribute {
 
   return {
     key: key,
-    value: value,
+    value: value || "",
   };
 }
 

--- a/packages/sdk/src/restclient.spec.ts
+++ b/packages/sdk/src/restclient.spec.ts
@@ -225,7 +225,7 @@ describe("RestClient", () => {
           .find(event => event.type === "message")
           ?.attributes.find(attr => attr.key === "contract_address");
         if (!contractAddressAttr) throw new Error("Could not find contract_address attribute");
-        contractAddress = contractAddressAttr.value || "";
+        contractAddress = contractAddressAttr.value;
 
         const balance = (await client.authAccounts(contractAddress)).result.value.coins;
         expect(balance).toEqual(transferAmount);

--- a/packages/sdk/types/logs.d.ts
+++ b/packages/sdk/types/logs.d.ts
@@ -1,6 +1,6 @@
 export interface Attribute {
   readonly key: string;
-  readonly value: string | undefined;
+  readonly value: string;
 }
 export interface Event {
   readonly type: "message" | "transfer";


### PR DESCRIPTION
Much better, especially since it simplifies the caller code.