### PR TITLE
Speed up wasmd

### DIFF
--- a/scripts/cosm/template/.wasmd/config/config.toml
+++ b/scripts/cosm/template/.wasmd/config/config.toml
@@ -262,13 +262,13 @@ version = "v0"
 
 wal_file = "data/cs.wal/wal"
 
-timeout_propose = "3s"
-timeout_propose_delta = "500ms"
-timeout_prevote = "1s"
-timeout_prevote_delta = "500ms"
-timeout_precommit = "1s"
-timeout_precommit_delta = "500ms"
-timeout_commit = "5s"
+timeout_propose = "300ms"
+timeout_propose_delta = "100ms"
+timeout_prevote = "300ms"
+timeout_prevote_delta = "100ms"
+timeout_precommit = "300ms"
+timeout_precommit_delta = "100ms"
+timeout_commit = "1s"
 
 # Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)
 skip_timeout_commit = false


### PR DESCRIPTION
Reduce wasmd block time from 5s to 1s via config

This brings down integration tests from 5->1 or 15->3s

We can speed it up more, but I'm not sure how stable this is at sub-second blocktimes (I haven't heard of such deployments... maybe it works). This should be good enough for now, and I have tried this speed many times with tendermint.