### PR TITLE
Export DirectSecp256k1Wallet from proto-signing package

### DIFF
--- a/packages/proto-signing/src/index.ts
+++ b/packages/proto-signing/src/index.ts
@@ -2,6 +2,7 @@ export { Coin } from "./msgs";
 export { cosmosField, registered } from "./decorator";
 export { EncodeObject, Registry } from "./registry";
 export { DirectSecp256k1HdWallet } from "./directsecp256k1hdwallet";
+export { DirectSecp256k1Wallet } from "./directsecp256k1wallet";
 export { decodePubkey, encodePubkey } from "./pubkey";
 export { isOfflineDirectSigner, OfflineDirectSigner, OfflineSigner } from "./signer";
 export { makeAuthInfoBytes, makeSignBytes, makeSignDoc } from "./signing";

--- a/packages/proto-signing/types/index.d.ts
+++ b/packages/proto-signing/types/index.d.ts
@@ -2,6 +2,7 @@ export { Coin } from "./msgs";
 export { cosmosField, registered } from "./decorator";
 export { EncodeObject, Registry } from "./registry";
 export { DirectSecp256k1HdWallet } from "./directsecp256k1hdwallet";
+export { DirectSecp256k1Wallet } from "./directsecp256k1wallet";
 export { decodePubkey, encodePubkey } from "./pubkey";
 export { isOfflineDirectSigner, OfflineDirectSigner, OfflineSigner } from "./signer";
 export { makeAuthInfoBytes, makeSignBytes, makeSignDoc } from "./signing";


### PR DESCRIPTION
@willclarktech, forgot to export `DirectSecp256k1Wallet` when I separated #518 into two different commits. Noticed today when I was trying to use it in our app. :sweat_smile: 