### PR TITLE
Prepare release of 0.24.0-alpha.7

### DIFF
--- a/packages/proto-signing/package.json
+++ b/packages/proto-signing/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@cosmjs/launchpad": "^0.24.0-alpha.6",
     "long": "^4.0.0",
-    "protobufjs": "~6.10.0"
+    "protobufjs": "~6.10.2"
   },
   "devDependencies": {
     "@cosmjs/encoding": "^0.24.0-alpha.6",

--- a/packages/stargate/README.md
+++ b/packages/stargate/README.md
@@ -6,10 +6,10 @@ A client library for the Cosmos SDK 0.40.
 
 ## Supported Cosmos SDK versions
 
-| CosmJS version | Supported Cosmos SDK version(s) |
-| -------------- | ------------------------------- |
-| 0.24.0-alpha.2 | 0.40.0-rc2                      |
-| 0.24.0-alpha.1 | 0.40.0-rc1                      |
+| CosmJS version                  | Supported Cosmos SDK version(s) |
+| ------------------------------- | ------------------------------- |
+| 0.24.0-alpha.2 – 0.24.0-alpha.7 | 0.40.0-rc2                      |
+| 0.24.0-alpha.1                  | 0.40.0-rc1                      |
 
 ## License
 

--- a/packages/stargate/package.json
+++ b/packages/stargate/package.json
@@ -56,6 +56,6 @@
     "@cosmjs/tendermint-rpc": "^0.24.0-alpha.6",
     "@cosmjs/utils": "^0.24.0-alpha.6",
     "long": "^4.0.0",
-    "protobufjs": "~6.10.0"
+    "protobufjs": "~6.10.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7156,10 +7156,10 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
-protobufjs@^6.8.8, protobufjs@~6.10.0:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.10.1.tgz#e6a484dd8f04b29629e9053344e3970cccf13cd2"
-  integrity sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==
+protobufjs@^6.8.8, protobufjs@~6.10.2:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.10.2.tgz#b9cb6bd8ec8f87514592ba3fdfd28e93f33a469b"
+  integrity sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
Closes #530

0.24.0-alpha.7 should be the last release targetting rc2. Next up #524, which we then need for wasmd 0.12.