### PR TITLE
Upgrade simapp to rc3

### DIFF
--- a/packages/proto-signing/package.json
+++ b/packages/proto-signing/package.json
@@ -42,7 +42,7 @@
     "coverage": "nyc --reporter=text --reporter=lcov yarn test --quiet",
     "pack-web": "yarn build-or-skip && webpack --mode development --config webpack.web.config.js",
     "preget-proto": "rm -rf proto",
-    "get-proto": "REF=v0.40.0-rc2 ./scripts/get-proto.sh",
+    "get-proto": "REF=v0.40.0-rc3 ./scripts/get-proto.sh",
     "predefine-proto": "./scripts/predefine-proto.sh",
     "define-proto": "./scripts/define-proto.sh",
     "postdefine-proto": "prettier --write \"src/codec/generated/codecimpl.*\""

--- a/packages/proto-signing/src/codec/generated/codecimpl.d.ts
+++ b/packages/proto-signing/src/codec/generated/codecimpl.d.ts
@@ -1965,6 +1965,9 @@ export namespace tendermint {
     interface IPublicKey {
       /** PublicKey ed25519 */
       ed25519?: Uint8Array | null;
+
+      /** PublicKey secp256k1 */
+      secp256k1?: Uint8Array | null;
     }
 
     /** Represents a PublicKey. */
@@ -1978,8 +1981,11 @@ export namespace tendermint {
       /** PublicKey ed25519. */
       public ed25519: Uint8Array;
 
+      /** PublicKey secp256k1. */
+      public secp256k1: Uint8Array;
+
       /** PublicKey sum. */
-      public sum?: "ed25519";
+      public sum?: "ed25519" | "secp256k1";
 
       /**
        * Creates a new PublicKey instance using the specified properties.

--- a/packages/proto-signing/src/codec/generated/codecimpl.js
+++ b/packages/proto-signing/src/codec/generated/codecimpl.js
@@ -1672,9 +1672,10 @@ exports.tendermint = $root.tendermint = (() => {
             if (p[ks[i]] != null) this[ks[i]] = p[ks[i]];
       }
       PublicKey.prototype.ed25519 = $util.newBuffer([]);
+      PublicKey.prototype.secp256k1 = $util.newBuffer([]);
       let $oneOfFields;
       Object.defineProperty(PublicKey.prototype, "sum", {
-        get: $util.oneOfGetter(($oneOfFields = ["ed25519"])),
+        get: $util.oneOfGetter(($oneOfFields = ["ed25519", "secp256k1"])),
         set: $util.oneOfSetter($oneOfFields),
       });
       PublicKey.create = function create(properties) {
@@ -1683,6 +1684,8 @@ exports.tendermint = $root.tendermint = (() => {
       PublicKey.encode = function encode(m, w) {
         if (!w) w = $Writer.create();
         if (m.ed25519 != null && Object.hasOwnProperty.call(m, "ed25519")) w.uint32(10).bytes(m.ed25519);
+        if (m.secp256k1 != null && Object.hasOwnProperty.call(m, "secp256k1"))
+          w.uint32(18).bytes(m.secp256k1);
         return w;
       };
       PublicKey.decode = function decode(r, l) {
@@ -1694,6 +1697,9 @@ exports.tendermint = $root.tendermint = (() => {
           switch (t >>> 3) {
             case 1:
               m.ed25519 = r.bytes();
+              break;
+            case 2:
+              m.secp256k1 = r.bytes();
               break;
             default:
               r.skipType(t & 7);

--- a/packages/proto-signing/types/codec/generated/codecimpl.d.ts
+++ b/packages/proto-signing/types/codec/generated/codecimpl.d.ts
@@ -1965,6 +1965,9 @@ export namespace tendermint {
     interface IPublicKey {
       /** PublicKey ed25519 */
       ed25519?: Uint8Array | null;
+
+      /** PublicKey secp256k1 */
+      secp256k1?: Uint8Array | null;
     }
 
     /** Represents a PublicKey. */
@@ -1978,8 +1981,11 @@ export namespace tendermint {
       /** PublicKey ed25519. */
       public ed25519: Uint8Array;
 
+      /** PublicKey secp256k1. */
+      public secp256k1: Uint8Array;
+
       /** PublicKey sum. */
-      public sum?: "ed25519";
+      public sum?: "ed25519" | "secp256k1";
 
       /**
        * Creates a new PublicKey instance using the specified properties.

--- a/packages/stargate/README.md
+++ b/packages/stargate/README.md
@@ -8,6 +8,7 @@ A client library for the Cosmos SDK 0.40.
 
 | CosmJS version                  | Supported Cosmos SDK version(s) |
 | ------------------------------- | ------------------------------- |
+| ^0.24.0-alpha.8                 | 0.40.0-rc3                      |
 | 0.24.0-alpha.2 – 0.24.0-alpha.7 | 0.40.0-rc2                      |
 | 0.24.0-alpha.1                  | 0.40.0-rc1                      |
 

--- a/packages/stargate/package.json
+++ b/packages/stargate/package.json
@@ -41,7 +41,7 @@
     "coverage": "nyc --reporter=text --reporter=lcov yarn test --quiet",
     "pack-web": "yarn build-or-skip && webpack --mode development --config webpack.web.config.js",
     "preget-proto": "rm -rf proto",
-    "get-proto": "REF=v0.40.0-rc2 ./scripts/get-proto.sh",
+    "get-proto": "REF=v0.40.0-rc3 ./scripts/get-proto.sh",
     "predefine-proto": "./scripts/predefine-proto.sh",
     "define-proto": "./scripts/define-proto.sh",
     "postdefine-proto": "prettier --write \"src/codec/generated/codecimpl.*\""

--- a/packages/stargate/src/codec/generated/codecimpl.d.ts
+++ b/packages/stargate/src/codec/generated/codecimpl.d.ts
@@ -12032,6 +12032,9 @@ export namespace tendermint {
     interface IPublicKey {
       /** PublicKey ed25519 */
       ed25519?: Uint8Array | null;
+
+      /** PublicKey secp256k1 */
+      secp256k1?: Uint8Array | null;
     }
 
     /** Represents a PublicKey. */
@@ -12045,8 +12048,11 @@ export namespace tendermint {
       /** PublicKey ed25519. */
       public ed25519: Uint8Array;
 
+      /** PublicKey secp256k1. */
+      public secp256k1: Uint8Array;
+
       /** PublicKey sum. */
-      public sum?: "ed25519";
+      public sum?: "ed25519" | "secp256k1";
 
       /**
        * Creates a new PublicKey instance using the specified properties.

--- a/packages/stargate/src/codec/generated/codecimpl.js
+++ b/packages/stargate/src/codec/generated/codecimpl.js
@@ -9370,9 +9370,10 @@ exports.tendermint = $root.tendermint = (() => {
             if (p[ks[i]] != null) this[ks[i]] = p[ks[i]];
       }
       PublicKey.prototype.ed25519 = $util.newBuffer([]);
+      PublicKey.prototype.secp256k1 = $util.newBuffer([]);
       let $oneOfFields;
       Object.defineProperty(PublicKey.prototype, "sum", {
-        get: $util.oneOfGetter(($oneOfFields = ["ed25519"])),
+        get: $util.oneOfGetter(($oneOfFields = ["ed25519", "secp256k1"])),
         set: $util.oneOfSetter($oneOfFields),
       });
       PublicKey.create = function create(properties) {
@@ -9381,6 +9382,8 @@ exports.tendermint = $root.tendermint = (() => {
       PublicKey.encode = function encode(m, w) {
         if (!w) w = $Writer.create();
         if (m.ed25519 != null && Object.hasOwnProperty.call(m, "ed25519")) w.uint32(10).bytes(m.ed25519);
+        if (m.secp256k1 != null && Object.hasOwnProperty.call(m, "secp256k1"))
+          w.uint32(18).bytes(m.secp256k1);
         return w;
       };
       PublicKey.decode = function decode(r, l) {
@@ -9392,6 +9395,9 @@ exports.tendermint = $root.tendermint = (() => {
           switch (t >>> 3) {
             case 1:
               m.ed25519 = r.bytes();
+              break;
+            case 2:
+              m.secp256k1 = r.bytes();
               break;
             default:
               r.skipType(t & 7);

--- a/packages/stargate/types/codec/generated/codecimpl.d.ts
+++ b/packages/stargate/types/codec/generated/codecimpl.d.ts
@@ -12032,6 +12032,9 @@ export namespace tendermint {
     interface IPublicKey {
       /** PublicKey ed25519 */
       ed25519?: Uint8Array | null;
+
+      /** PublicKey secp256k1 */
+      secp256k1?: Uint8Array | null;
     }
 
     /** Represents a PublicKey. */
@@ -12045,8 +12048,11 @@ export namespace tendermint {
       /** PublicKey ed25519. */
       public ed25519: Uint8Array;
 
+      /** PublicKey secp256k1. */
+      public secp256k1: Uint8Array;
+
       /** PublicKey sum. */
-      public sum?: "ed25519";
+      public sum?: "ed25519" | "secp256k1";
 
       /**
        * Creates a new PublicKey instance using the specified properties.

--- a/packages/tendermint-rpc/src/adaptorforversion.ts
+++ b/packages/tendermint-rpc/src/adaptorforversion.ts
@@ -5,7 +5,10 @@ import { Adaptor } from "./adaptor";
 import { v0_33 } from "./v0-33";
 
 const hashes = {
-  v0_34: ["ca2c9df"],
+  v0_34: [
+    "ca2c9df", // v0.34.0-rc6
+    "", // See https://github.com/cosmos/cosmos-sdk/issues/7963
+  ],
 };
 
 /**

--- a/packages/tendermint-rpc/src/v0-33/responses.ts
+++ b/packages/tendermint-rpc/src/v0-33/responses.ts
@@ -502,7 +502,9 @@ function decodeNodeInfo(data: RpcNodeInfo): responses.NodeInfo {
     id: fromHex(assertNotEmpty(data.id)),
     listenAddr: assertNotEmpty(data.listen_addr),
     network: assertNotEmpty(data.network),
-    version: assertNotEmpty(data.version),
+    // TODO: Reactivate check when https://github.com/cosmos/cosmos-sdk/issues/7963 is resolved
+    // version: assertNotEmpty(data.version),
+    version: data.version,
     channels: assertNotEmpty(data.channels),
     moniker: assertNotEmpty(data.moniker),
     other: dictionaryToStringMap(data.other),

--- a/scripts/simapp/env
+++ b/scripts/simapp/env
@@ -1,4 +1,4 @@
 # Choose from https://hub.docker.com/r/interchainio/simapp/tags
 REPOSITORY="interchainio/simapp"
-VERSION="v0.40.0-rc2"
+VERSION="v0.40.0-rc3"
 CONTAINER_NAME="simapp"


### PR DESCRIPTION
Closes #524

The upgrade seems to be simple, but unfortunately our Tendermint RPC client cannot determine the backend's Tendermint version (https://github.com/cosmos/cosmos-sdk/issues/7963).