### PR TITLE
Fix Stargate codec export

### DIFF
--- a/packages/stargate/src/codec/index.ts
+++ b/packages/stargate/src/codec/index.ts
@@ -1,3 +1,8 @@
+/**
+ * This codec is derived from the Cosmos SDK protocol buffer definitions and can change at any time.
+ * @packageDocumentation
+ */
+
 import Long from "long";
 import protobuf from "protobufjs/minimal";
 

--- a/packages/stargate/src/index.ts
+++ b/packages/stargate/src/index.ts
@@ -1,4 +1,4 @@
-import * as codecImport from "./codec";
+export * as codec from "./codec";
 export {
   AuthExtension,
   BankExtension,
@@ -10,6 +10,3 @@ export {
 } from "./queries";
 export { assertIsBroadcastTxSuccess, StargateClient } from "./stargateclient";
 export { SigningStargateClient } from "./signingstargateclient";
-
-/** This codec is derived from the Cosmos SDK protocol buffer definitions and can change at any time. */
-export const codec = codecImport;

--- a/packages/stargate/types/codec/index.d.ts
+++ b/packages/stargate/types/codec/index.d.ts
@@ -1,1 +1,5 @@
+/**
+ * This codec is derived from the Cosmos SDK protocol buffer definitions and can change at any time.
+ * @packageDocumentation
+ */
 export * from "./generated/codecimpl";

--- a/packages/stargate/types/index.d.ts
+++ b/packages/stargate/types/index.d.ts
@@ -1,4 +1,4 @@
-import * as codecImport from "./codec";
+export * as codec from "./codec";
 export {
   AuthExtension,
   BankExtension,
@@ -10,5 +10,3 @@ export {
 } from "./queries";
 export { assertIsBroadcastTxSuccess, StargateClient } from "./stargateclient";
 export { SigningStargateClient } from "./signingstargateclient";
-/** This codec is derived from the Cosmos SDK protocol buffer definitions and can change at any time. */
-export declare const codec: typeof codecImport;


### PR DESCRIPTION
As revealed by IBC visualizer. This is the best option I've found to preserve the typedoc comment, but there are so many permutations of imports/exports/modules/namespaces I'm not certain there isn't a better way.