### PR TITLE
Bump simapp to v0.40.0-rc7

### DIFF
--- a/scripts/simapp/env
+++ b/scripts/simapp/env
@@ -1,4 +1,4 @@
 # Choose from https://hub.docker.com/r/interchainio/simapp/tags
 REPOSITORY="interchainio/simapp"
-VERSION="v0.40.0-rc3"
+VERSION="v0.40.0-rc7"
 CONTAINER_NAME="simapp"


### PR DESCRIPTION
Closes #607 

This doesn't work as the genesis file has changed - a number of IBC changes that need to be adapted.