### PR TITLE
Query client proof helper

### DIFF
--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -139,7 +139,7 @@ export class SigningStargateClient extends StargateClient {
       throw new Error("Failed to retrieve account from signer");
     }
     const pubkey = encodeSecp256k1Pubkey(accountFromSigner.pubkey);
-    const accountFromChain = await this.getAccountUnverified(signerAddress);
+    const accountFromChain = await this.getAccount(signerAddress);
     if (!accountFromChain) {
       throw new Error("Account not found");
     }

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -139,7 +139,7 @@ export class SigningStargateClient extends StargateClient {
       throw new Error("Failed to retrieve account from signer");
     }
     const pubkey = encodeSecp256k1Pubkey(accountFromSigner.pubkey);
-    const accountFromChain = await this.getAccount(signerAddress);
+    const accountFromChain = await this.getAccountUnverified(signerAddress);
     if (!accountFromChain) {
       throw new Error("Account not found");
     }

--- a/packages/stargate/src/stargateclient.ts
+++ b/packages/stargate/src/stargateclient.ts
@@ -149,8 +149,16 @@ export class StargateClient {
     return status.syncInfo.latestBlockHeight;
   }
 
+  // this is nice to display data to the user, but is slower
   public async getAccount(searchAddress: string): Promise<Account | null> {
     const account = await this.queryClient.auth.account(searchAddress);
+    return account ? accountFromProto(account) : null;
+  }
+
+  // if we just need to get the sequence for signing a transaction, let's make this faster
+  // (no need to wait a block before submitting)
+  public async getAccountUnverified(searchAddress: string): Promise<Account | null> {
+    const account = await this.queryClient.auth.unverified.account(searchAddress);
     return account ? accountFromProto(account) : null;
   }
 

--- a/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts
+++ b/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts
@@ -71,7 +71,7 @@ interface RpcAbciQueryResponse {
   readonly key: string;
   /** base64 encoded */
   readonly value?: string;
-  readonly proof?: RpcQueryProof;
+  readonly proofOps?: RpcQueryProof;
   readonly height?: string;
   readonly index?: string;
   readonly code?: string; // only for errors
@@ -82,7 +82,7 @@ function decodeAbciQuery(data: RpcAbciQueryResponse): responses.AbciQueryRespons
   return {
     key: fromBase64(optional(data.key, "")),
     value: fromBase64(optional(data.value, "")),
-    proof: may(decodeQueryProof, data.proof),
+    proof: may(decodeQueryProof, data.proofOps),
     height: may(Integer.parse, data.height),
     code: may(Integer.parse, data.code),
     index: may(Integer.parse, data.index),


### PR DESCRIPTION
Closes #651 

This will let us get the full proof data from a QueryClient helper, so we can use it in a QueryExtension.
This function does the basic format validation but not the actual merkle / light client proof. It is a useful primitive to expose and we can use it to build the more complex calls.
