### PR TITLE
Add validatorsAll query method to tendermint-rpc

### DIFF
--- a/packages/tendermint-rpc/src/adaptors/v0-33/requests.ts
+++ b/packages/tendermint-rpc/src/adaptors/v0-33/requests.ts
@@ -84,6 +84,19 @@ function encodeTxSearchParams(params: requests.TxSearchParams): RpcTxSearchParam
   };
 }
 
+interface RpcValidatorsParams {
+  readonly height?: string;
+  readonly page?: string;
+  readonly per_page?: string;
+}
+function encodeValidatorsParams(params: requests.ValidatorsParams): RpcValidatorsParams {
+  return {
+    height: may(Integer.encode, params.height),
+    page: may(Integer.encode, params.page),
+    per_page: may(Integer.encode, params.per_page),
+  };
+}
+
 export class Params {
   public static encodeAbciInfo(req: requests.AbciInfoRequest): JsonRpcRequest {
     return createJsonRpcRequest(req.method);
@@ -141,6 +154,6 @@ export class Params {
   }
 
   public static encodeValidators(req: requests.ValidatorsRequest): JsonRpcRequest {
-    return createJsonRpcRequest(req.method, encodeHeightParam(req.params));
+    return createJsonRpcRequest(req.method, encodeValidatorsParams(req.params));
   }
 }

--- a/packages/tendermint-rpc/src/client.spec.ts
+++ b/packages/tendermint-rpc/src/client.spec.ts
@@ -148,6 +148,24 @@ function defaultTestSuite(rpcFactory: () => RpcClient, adaptor: Adaptor, expecte
     client.disconnect();
   });
 
+  it("can get all validators", async () => {
+    pendingWithoutTendermint();
+    const client = await Client.create(rpcFactory(), adaptor);
+    const response = await client.validatorsAll({});
+
+    expect(response).toBeTruthy();
+    expect(response.blockHeight).toBeGreaterThanOrEqual(1);
+    expect(response.count).toBeGreaterThanOrEqual(1);
+    expect(response.total).toBeGreaterThanOrEqual(1);
+    expect(response.validators.length).toBeGreaterThanOrEqual(1);
+    expect(response.validators[0].address.length).toEqual(20);
+    expect(response.validators[0].pubkey).toBeDefined();
+    expect(response.validators[0].votingPower).toBeGreaterThanOrEqual(0);
+    expect(response.validators[0].proposerPriority).toBeGreaterThanOrEqual(0);
+
+    client.disconnect();
+  });
+
   it("can call a bunch of methods", async () => {
     pendingWithoutTendermint();
     const client = await Client.create(rpcFactory(), adaptor);

--- a/packages/tendermint-rpc/src/client.spec.ts
+++ b/packages/tendermint-rpc/src/client.spec.ts
@@ -133,7 +133,7 @@ function defaultTestSuite(rpcFactory: () => RpcClient, adaptor: Adaptor, expecte
   it("can get validators", async () => {
     pendingWithoutTendermint();
     const client = await Client.create(rpcFactory(), adaptor);
-    const response = await client.validators();
+    const response = await client.validators({});
 
     expect(response).toBeTruthy();
     expect(response.blockHeight).toBeGreaterThanOrEqual(1);

--- a/packages/tendermint-rpc/src/client.spec.ts
+++ b/packages/tendermint-rpc/src/client.spec.ts
@@ -151,7 +151,7 @@ function defaultTestSuite(rpcFactory: () => RpcClient, adaptor: Adaptor, expecte
   it("can get all validators", async () => {
     pendingWithoutTendermint();
     const client = await Client.create(rpcFactory(), adaptor);
-    const response = await client.validatorsAll({});
+    const response = await client.validatorsAll();
 
     expect(response).toBeTruthy();
     expect(response.blockHeight).toBeGreaterThanOrEqual(1);

--- a/packages/tendermint-rpc/src/client.ts
+++ b/packages/tendermint-rpc/src/client.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { Stream } from "xstream";
 
 import { Adaptor, Decoder, Encoder, Params, Responses } from "./adaptor";
@@ -254,6 +255,35 @@ export class Client {
       params: params,
     };
     return this.doCall(query, this.p.encodeValidators, this.r.decodeValidators);
+  }
+
+  public async validatorsAll(params: requests.ValidatorsParams): Promise<responses.ValidatorsResponse> {
+    let page = params.page || 1;
+    const validators: responses.Validator[] = [];
+    let done = false;
+    let blockHeight = 0;
+
+    while (!done) {
+      const resp = await this.validators({
+        per_page: 50,
+        ...params,
+        page: page,
+      });
+      validators.push(...resp.validators);
+      blockHeight = resp.blockHeight;
+      if (validators.length < resp.total) {
+        page++;
+      } else {
+        done = true;
+      }
+    }
+
+    return {
+      blockHeight: blockHeight,
+      count: validators.length,
+      total: validators.length,
+      validators: validators,
+    };
   }
 
   // doCall is a helper to handle the encode/call/decode logic

--- a/packages/tendermint-rpc/src/client.ts
+++ b/packages/tendermint-rpc/src/client.ts
@@ -248,10 +248,10 @@ export class Client {
     };
   }
 
-  public async validators(height?: number): Promise<responses.ValidatorsResponse> {
+  public async validators(params: requests.ValidatorsParams): Promise<responses.ValidatorsResponse> {
     const query: requests.ValidatorsRequest = {
       method: requests.Method.Validators,
-      params: { height: height },
+      params: params,
     };
     return this.doCall(query, this.p.encodeValidators, this.r.decodeValidators);
   }

--- a/packages/tendermint-rpc/src/client.ts
+++ b/packages/tendermint-rpc/src/client.ts
@@ -260,13 +260,17 @@ export class Client {
   public async validatorsAll(params: requests.ValidatorsParams): Promise<responses.ValidatorsResponse> {
     let page = params.page || 1;
     const validators: responses.Validator[] = [];
+    const baseParams = {
+      per_page: 50,
+      height: params.height ?? (await this.status()).syncInfo.latestBlockHeight,
+      ...params,
+    };
     let done = false;
     let blockHeight = 0;
 
     while (!done) {
       const resp = await this.validators({
-        per_page: 50,
-        ...params,
+        ...baseParams,
         page: page,
       });
       validators.push(...resp.validators);

--- a/packages/tendermint-rpc/src/index.ts
+++ b/packages/tendermint-rpc/src/index.ts
@@ -31,6 +31,7 @@ export {
   TxSearchParams,
   TxSearchRequest,
   ValidatorsRequest,
+  ValidatorsParams,
 } from "./requests";
 export {
   AbciInfoResponse,

--- a/packages/tendermint-rpc/src/requests.ts
+++ b/packages/tendermint-rpc/src/requests.ts
@@ -161,9 +161,13 @@ export interface TxSearchParams {
 
 export interface ValidatorsRequest {
   readonly method: Method.Validators;
-  readonly params: {
-    readonly height?: number;
-  };
+  readonly params: ValidatorsParams;
+}
+
+export interface ValidatorsParams {
+  readonly height?: number;
+  readonly page?: number;
+  readonly per_page?: number;
 }
 
 export interface BuildQueryComponents {


### PR DESCRIPTION
Merge after #664 
Closes #660

I added a separate method on the model of `txSearch`/`txSearchAll`.