### PR TITLE
Simple query to get sequence to sign

### DIFF
--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -138,7 +138,7 @@ export class SigningStargateClient extends StargateClient {
       throw new Error("Failed to retrieve account from signer");
     }
     const pubkey = encodeSecp256k1Pubkey(accountFromSigner.pubkey);
-    const accountFromChain = await this.getAccount(signerAddress);
+    const accountFromChain = await this.getAccountUnverified(signerAddress);
     if (!accountFromChain) {
       throw new Error("Account not found");
     }


### PR DESCRIPTION
There is no real reason we need merkle proofs to check out sequence and accountNumber (if we really care, we track them locally). By using the verifying query here, we take 1 block for the query (it must wait for next header), then a second block to process the transaction. That means submitting transactions are twice as slow as they need to be.

They are the slowest thing in the system, let's try to speed them up a bit.

(Pulled this out of another PR so we can debate this point separate from proof bugfixes)