### PR TITLE
Return gas used

### DIFF
--- a/packages/cosmwasm-stargate/src/cosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.ts
@@ -180,6 +180,7 @@ export class CosmWasmClient {
         transactionHash: toHex(response.hash).toUpperCase(),
         rawLog: response.deliverTx?.log,
         data: response.deliverTx?.data ? TxMsgData.decode(response.deliverTx?.data).data : undefined,
+        gasUsed: response.deliverTx?.gasUsed || 0,
       };
     }
     return response.checkTx.code !== 0
@@ -192,7 +193,7 @@ export class CosmWasmClient {
         }
       : {
           height: response.height,
-          code: response.deliverTx?.code,
+          code: response.deliverTx?.code || 0,
           transactionHash: toHex(response.hash).toUpperCase(),
           rawLog: response.deliverTx?.log,
           data: response.deliverTx?.data ? TxMsgData.decode(response.deliverTx?.data).data : undefined,

--- a/packages/stargate/src/stargateclient.ts
+++ b/packages/stargate/src/stargateclient.ts
@@ -62,6 +62,7 @@ export interface BroadcastTxSuccess {
   readonly transactionHash: string;
   readonly rawLog?: string;
   readonly data?: readonly MsgData[];
+  readonly gasUsed: number;
 }
 
 export type BroadcastTxResponse = BroadcastTxSuccess | BroadcastTxFailure;
@@ -262,6 +263,7 @@ export class StargateClient {
         transactionHash: toHex(response.hash).toUpperCase(),
         rawLog: response.deliverTx?.log,
         data: response.deliverTx?.data ? TxMsgData.decode(response.deliverTx?.data).data : undefined,
+        gasUsed: response.deliverTx?.gasUsed || 0,
       };
     }
     return response.checkTx.code !== 0
@@ -274,7 +276,7 @@ export class StargateClient {
         }
       : {
           height: response.height,
-          code: response.deliverTx?.code,
+          code: response.deliverTx?.code || 0,
           transactionHash: toHex(response.hash).toUpperCase(),
           rawLog: response.deliverTx?.log,
           data: response.deliverTx?.data ? TxMsgData.decode(response.deliverTx?.data).data : undefined,

--- a/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts
+++ b/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts
@@ -133,7 +133,7 @@ interface RpcTxData {
   readonly events: readonly RpcEvent[];
   readonly codespace?: string;
   // string encoded numbers
-  readonly gas_wanted: string;
+  readonly gas_wanted?: string;
   readonly gas_used?: string;
 }
 
@@ -143,7 +143,7 @@ function decodeTxData(data: RpcTxData): responses.TxData {
     log: data.log,
     code: Integer.parse(assertNumber(optional<number>(data.code, 0))),
     events: decodeEvents(data.events),
-    gasWanted: Integer.parse(assertSet(data.gas_wanted)),
+    gasWanted: Integer.parse(optional(data.gas_wanted, "0")),
     gasUsed: Integer.parse(optional(data.gas_used, "0")),
   };
 }

--- a/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts
+++ b/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts
@@ -131,6 +131,10 @@ interface RpcTxData {
   /** base64 encoded */
   readonly data?: string;
   readonly events: readonly RpcEvent[];
+  readonly codespace?: string;
+  // string encoded numbers
+  readonly gas_wanted: string;
+  readonly gas_used?: string;
 }
 
 function decodeTxData(data: RpcTxData): responses.TxData {
@@ -139,6 +143,8 @@ function decodeTxData(data: RpcTxData): responses.TxData {
     log: data.log,
     code: Integer.parse(assertNumber(optional<number>(data.code, 0))),
     events: decodeEvents(data.events),
+    gasWanted: Integer.parse(assertSet(data.gas_wanted)),
+    gasUsed: Integer.parse(optional(data.gas_used, "0")),
   };
 }
 

--- a/packages/tendermint-rpc/src/responses.ts
+++ b/packages/tendermint-rpc/src/responses.ts
@@ -178,7 +178,7 @@ export interface TxData {
   readonly log?: string;
   readonly data?: Uint8Array;
   readonly events: readonly Event[];
-  readonly gasWanted: number;
+  readonly gasWanted?: number;
   readonly gasUsed?: number;
 }
 

--- a/packages/tendermint-rpc/src/responses.ts
+++ b/packages/tendermint-rpc/src/responses.ts
@@ -171,12 +171,15 @@ export interface Event {
   readonly attributes: readonly Attribute[];
 }
 
+// All fields are defined here: https://github.com/tendermint/tendermint/blob/v0.34.2/abci/types/types.pb.go#L2061-L2070
 export interface TxData {
   readonly code: number;
+  readonly codeSpace?: string;
   readonly log?: string;
   readonly data?: Uint8Array;
   readonly events: readonly Event[];
-  // readonly fees?: any;
+  readonly gasWanted: number;
+  readonly gasUsed?: number;
 }
 
 export interface TxProof {


### PR DESCRIPTION
This is very useful info in the apps when constructing transactions, so we can adjust the gas and fees for submitting transactions. We get it from tendermint rpc, but didn't parse it nor return it in the StargateClient.

This adds the extra info.

TODO: also add codespace, which is important along with the code for identifying errors