### PR TITLE
Nanoseconds on commit sigs

### DIFF
--- a/packages/tendermint-rpc/src/adaptors/v0-33/hasher.spec.ts
+++ b/packages/tendermint-rpc/src/adaptors/v0-33/hasher.spec.ts
@@ -1,7 +1,7 @@
 import { fromBase64, fromHex } from "@cosmjs/encoding";
 import { ReadonlyDate } from "readonly-date";
 
-import { ReadonlyDateWithNanoseconds } from "../../responses";
+import { ReadonlyDateWithNanoseconds } from "../../types";
 import { hashBlock, hashTx } from "./hasher";
 
 describe("Hasher", () => {

--- a/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts
+++ b/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts
@@ -417,7 +417,7 @@ function decodeCommitSignature(data: RpcSignature): CommitSignature {
   return {
     blockIdFlag: decodeBlockIdFlag(data.block_id_flag),
     validatorAddress: fromHex(data.validator_address),
-    timestamp: new Date(assertNotEmpty(data.timestamp)),
+    timestamp: DateTime.decode(assertNotEmpty(data.timestamp)),
     signature: fromBase64(assertNotEmpty(data.signature)),
   };
 }

--- a/packages/tendermint-rpc/src/encodings.spec.ts
+++ b/packages/tendermint-rpc/src/encodings.spec.ts
@@ -9,7 +9,7 @@ import {
   encodeTime,
   encodeVersion,
 } from "./encodings";
-import { ReadonlyDateWithNanoseconds } from "./responses";
+import { ReadonlyDateWithNanoseconds } from "./types";
 
 describe("encodings", () => {
   describe("DateTime", () => {

--- a/packages/tendermint-rpc/src/encodings.ts
+++ b/packages/tendermint-rpc/src/encodings.ts
@@ -1,7 +1,8 @@
 import { fromRfc3339, toUtf8 } from "@cosmjs/encoding";
 import { Int53 } from "@cosmjs/math";
 
-import { BlockId, ReadonlyDateWithNanoseconds, Version } from "./responses";
+import { BlockId, Version } from "./responses";
+import { ReadonlyDateWithNanoseconds } from "./types";
 
 /**
  * A runtime checker that ensures a given value is set (i.e. not undefined or null)

--- a/packages/tendermint-rpc/src/index.ts
+++ b/packages/tendermint-rpc/src/index.ts
@@ -56,7 +56,6 @@ export {
   NodeInfo,
   ProofOp,
   QueryProof,
-  ReadonlyDateWithNanoseconds,
   Response,
   StatusResponse,
   SyncInfo,
@@ -73,4 +72,10 @@ export {
   VoteType,
 } from "./responses";
 export { HttpClient, WebsocketClient } from "./rpcclients"; // TODO: Why do we export those outside of this package?
-export { BlockIdFlag, CommitSignature, ValidatorEd25519Pubkey, ValidatorPubkey } from "./types";
+export {
+  BlockIdFlag,
+  CommitSignature,
+  ReadonlyDateWithNanoseconds,
+  ValidatorEd25519Pubkey,
+  ValidatorPubkey,
+} from "./types";

--- a/packages/tendermint-rpc/src/responses.ts
+++ b/packages/tendermint-rpc/src/responses.ts
@@ -1,6 +1,6 @@
 import { ReadonlyDate } from "readonly-date";
 
-import { CommitSignature, ValidatorPubkey } from "./types";
+import { CommitSignature, ReadonlyDateWithNanoseconds, ValidatorPubkey } from "./types";
 
 export type Response =
   | AbciInfoResponse
@@ -251,11 +251,6 @@ export interface Vote {
 export interface Version {
   readonly block: number;
   readonly app: number;
-}
-
-export interface ReadonlyDateWithNanoseconds extends ReadonlyDate {
-  /* Nanoseconds after the time stored in a vanilla ReadonlyDate (millisecond granularity) */
-  readonly nanoseconds?: number;
 }
 
 // https://github.com/tendermint/tendermint/blob/v0.31.8/docs/spec/blockchain/blockchain.md

--- a/packages/tendermint-rpc/src/types.ts
+++ b/packages/tendermint-rpc/src/types.ts
@@ -1,5 +1,11 @@
 // Types in this file are exported outside of the @cosmjs/tendermint-rpc package,
 // e.g. as part of a request or response
+import { ReadonlyDate } from "readonly-date";
+
+export interface ReadonlyDateWithNanoseconds extends ReadonlyDate {
+  /* Nanoseconds after the time stored in a vanilla ReadonlyDate (millisecond granularity) */
+  readonly nanoseconds?: number;
+}
 
 export interface ValidatorEd25519Pubkey {
   readonly algorithm: "ed25519";
@@ -23,6 +29,6 @@ export enum BlockIdFlag {
 export interface CommitSignature {
   blockIdFlag: BlockIdFlag;
   validatorAddress: Uint8Array;
-  timestamp?: Date;
+  timestamp?: ReadonlyDateWithNanoseconds;
   signature: Uint8Array;
 }


### PR DESCRIPTION
Turns out we do need them for all the sign bytes to validate.