### PR TITLE
Allow empty value on event attributes

### DIFF
--- a/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts
+++ b/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts
@@ -101,7 +101,7 @@ interface RpcAttribute {
 function decodeAttribute(attribute: RpcAttribute): responses.Attribute {
   return {
     key: fromBase64(assertNotEmpty(attribute.key)),
-    value: fromBase64(assertNotEmpty(attribute.value)),
+    value: fromBase64(optional(attribute.value, "")),
   };
 }
 


### PR DESCRIPTION
This came up while parsing ibc transactions. In particular, with this broadcastTxResponse:

```js
{
  height: 10245,
  transactionHash: '3E321F6479D52D300B40E13C84411E2DE469F9F6358F6E817DEB38F0C78148BF',
  rawLog: '[{"events":[{"type":"connection_open_init","attributes":[{"key":"connection_id","value":"connection-7"},{"key":"client_id","value":"07-tendermint-10"},{"key":"counterparty_client_id","value":"07-tendermint-22"},{"key":"counterparty_connection_id"}]},{"type":"message","attributes":[{"key":"action","value":"connection_open_init"},{"key":"module","value":"ibc_connection"}]}]}]',
  data: [ { msgType: 'connection_open_init' } ]
}
```

Note the `{"key":"counterparty_connection_id"}` inside there. Currently this causes `signAndBroadcast` to panic on a sanity check:

```
  Error {
    message: 'must provide a non-empty value',
  }

  › Object.assertNotEmpty (/home/ethan/js/cosmjs/packages/tendermint-rpc/src/encodings.ts:121:11)
  › decodeAttribute (/home/ethan/js/cosmjs/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts:104:23)
  › Array.map (<anonymous>)
  › decodeAttributes (/home/ethan/js/cosmjs/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts:109:34)
  › decodeEvent (/home/ethan/js/cosmjs/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts:120:17)
  › Array.map (<anonymous>)
  › decodeEvents (/home/ethan/js/cosmjs/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts:125:30)
  › decodeTxData (/home/ethan/js/cosmjs/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts:141:13)
  › Object.may (/home/ethan/js/cosmjs/packages/tendermint-rpc/src/encodings.ts:133:62)
  › decodeBroadcastTxCommit (/home/ethan/js/cosmjs/packages/tendermint-rpc/src/adaptors/v0-33/responses.ts:398:16)
```