### PR TITLE
Added delegateTokens method to SigningStargateClient

### DIFF
--- a/packages/stargate/src/signingstargateclient.spec.ts
+++ b/packages/stargate/src/signingstargateclient.spec.ts
@@ -44,6 +44,15 @@ describe("SigningStargateClient", () => {
           ],
           gas: "80000",
         },
+        delegate: {
+          amount: [
+            {
+              amount: "4000",
+              denom: "ucosm",
+            },
+          ],
+          gas: "160000",
+        },
       });
     });
 
@@ -75,6 +84,15 @@ describe("SigningStargateClient", () => {
           ],
           gas: "80000",
         },
+        delegate: {
+          amount: [
+            {
+              amount: "502400", // 3.14 * 160_000
+              denom: "utest",
+            },
+          ],
+          gas: "160000",
+        },
       });
     });
 
@@ -83,6 +101,7 @@ describe("SigningStargateClient", () => {
       const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic);
       const gasLimits = {
         send: 160000,
+        delegate: 120000,
       };
       const options = { gasLimits: gasLimits };
       const client = await SigningStargateClient.connectWithSigner(simapp.tendermintUrl, wallet, options);
@@ -97,6 +116,15 @@ describe("SigningStargateClient", () => {
           ],
           gas: "160000",
         },
+        delegate: {
+          amount: [
+            {
+              amount: "3000", // 0.025 * 120_000
+              denom: "ucosm",
+            },
+          ],
+          gas: "120000",
+        },
       });
     });
 
@@ -106,12 +134,22 @@ describe("SigningStargateClient", () => {
       const gasPrice = GasPrice.fromString("3.14utest");
       const gasLimits = {
         send: 160000,
+        delegate: 160000,
       };
       const options = { gasPrice: gasPrice, gasLimits: gasLimits };
       const client = await SigningStargateClient.connectWithSigner(simapp.tendermintUrl, wallet, options);
       const openedClient = (client as unknown) as PrivateSigningStargateClient;
       expect(openedClient.fees).toEqual({
         send: {
+          amount: [
+            {
+              amount: "502400", // 3.14 * 160_000
+              denom: "utest",
+            },
+          ],
+          gas: "160000",
+        },
+        delegate: {
           amount: [
             {
               amount: "502400", // 3.14 * 160_000


### PR DESCRIPTION
Closes #687 

I just added the first of 3 messages, but already this is getting a bit ugly, meaning I am touching stuff I probably should not.

1. Adding a delegate StdFee to the FeeTable makes it required everywhere. This means I have to fix 5 tests. I guess https://github.com/cosmos/cosmjs/issues/686 would make it much easier.
2. I didn't want to break all the Launchpad use-cases, so I copied over the CosmosFeeTable interface into stargate. (Which is part of #657)
3. We will also need the same code in `cosmwasm-stargate`. Is there a better approach than copy-pasting these methods?

I can continue, but seeing what I have to change, I wonder if it makes sense to address those issues as a separate PR first, then finish this? 

Update: I just added the rest of the messages as methods, but didn't bother to fix all the code that broke by adding more fields to CosmosGasLimit, as #686 will obviate the need for this all. I'd be happy for some feedback and/or someone else to pick this up and make the infrastructure changes needed to do it right.

I would like this in, so I can update the wallet to alpha.25 (26?) and at the same time allow many other wallets to have a much easier integration path.