### PR TITLE
Properly handle missing commit signatures

### DIFF
--- a/packages/tendermint-rpc/src/tendermint34/adaptors/v0-34/responses.ts
+++ b/packages/tendermint-rpc/src/tendermint34/adaptors/v0-34/responses.ts
@@ -409,18 +409,24 @@ type RpcSignature = {
   /** hex encoded */
   readonly validator_address: string;
   readonly timestamp: string;
-  /** bae64 encoded */
-  readonly signature: string;
+  /**
+   * Base64 encoded signature.
+   * There are cases when this is not set, see https://github.com/cosmos/cosmjs/issues/704#issuecomment-797122415.
+   */
+  readonly signature: string | null;
 };
 
 function decodeCommitSignature(data: RpcSignature): CommitSignature {
   const nonZeroTime = data.timestamp && !data.timestamp.startsWith("0001-01-01");
   return {
     blockIdFlag: decodeBlockIdFlag(data.block_id_flag),
+    // FIXME: Return an optional validatorAddress instead of an empty Uint8Array
+    // in the next breaking release.
     validatorAddress: fromHex(data.validator_address),
     timestamp: nonZeroTime ? fromRfc3339WithNanoseconds(data.timestamp) : undefined,
-    // FIXME: make this optional in type? (signature?: Uint8Array)
-    signature: fromBase64(optional(data.signature, "")),
+    // FIXME: Return an optional signature instead of an empty Uint8Array
+    // in the next breaking release.
+    signature: fromBase64(data.signature || ""),
   };
 }
 

--- a/packages/tendermint-rpc/src/tendermint34/adaptors/v0-34/responses.ts
+++ b/packages/tendermint-rpc/src/tendermint34/adaptors/v0-34/responses.ts
@@ -414,11 +414,13 @@ type RpcSignature = {
 };
 
 function decodeCommitSignature(data: RpcSignature): CommitSignature {
+  const nonZeroTime = data.timestamp && !data.timestamp.startsWith("0001-01-01");
   return {
     blockIdFlag: decodeBlockIdFlag(data.block_id_flag),
     validatorAddress: fromHex(data.validator_address),
-    timestamp: fromRfc3339WithNanoseconds(assertNotEmpty(data.timestamp)),
-    signature: fromBase64(assertNotEmpty(data.signature)),
+    timestamp: nonZeroTime ? fromRfc3339WithNanoseconds(data.timestamp) : undefined,
+    // FIXME: make this optional in type? (signature?: Uint8Array)
+    signature: fromBase64(optional(data.signature, "")),
   };
 }
 

--- a/packages/tendermint-rpc/src/types.ts
+++ b/packages/tendermint-rpc/src/types.ts
@@ -23,6 +23,7 @@ export enum BlockIdFlag {
 }
 
 export interface CommitSignature {
+  /** If this is BlockIdFlag.Absent, all other fields are expected to be unset */
   blockIdFlag: BlockIdFlag;
   validatorAddress: Uint8Array;
   timestamp?: ReadonlyDateWithNanoseconds;


### PR DESCRIPTION
Closes #704 

Needed for the relayer to connect to musselnet. 

Can we backport this to a 0.24.1 release? Easier to update the relayer, but I can also just follow 0.25.0-alphas