### PR TITLE
Make CommitSignature fields optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to
 
 - @cosmjs/cosmwasm-stargate: Codec adapted to support wasmd 0.16. Older versions
   of wasmd are not supported anymore.
+- @cosmjs/tendermint-rpc: The fields `CommitSignature.validatorAddress`,
+  `.timestamp` and `.signature` are now optional. They are unset when
+  `blockIdFlag` is `BlockIdFlag.Absent`. The decoding into `CommitSignature` is
+  only updated for the class `Tendermint34Client`, not for `Client`. Please
+  migrate to the former.
 
 ## [0.24.0] - 2021-03-11
 

--- a/packages/tendermint-rpc/src/legacy/client.spec.ts
+++ b/packages/tendermint-rpc/src/legacy/client.spec.ts
@@ -105,9 +105,9 @@ function defaultTestSuite(rpcFactory: () => RpcClient, adaptor: Adaptor, expecte
     expect(response).toBeTruthy();
     expect(response.commit.signatures.length).toBeGreaterThanOrEqual(1);
     expect(response.commit.signatures[0].blockIdFlag).toEqual(2);
-    expect(response.commit.signatures[0].validatorAddress.length).toEqual(20);
+    expect(response.commit.signatures[0].validatorAddress?.length).toEqual(20);
     expect(response.commit.signatures[0].timestamp).toBeInstanceOf(Date);
-    expect(response.commit.signatures[0].signature.length).toEqual(64);
+    expect(response.commit.signatures[0].signature?.length).toEqual(64);
 
     client.disconnect();
   });

--- a/packages/tendermint-rpc/src/tendermint34/tendermint34client.spec.ts
+++ b/packages/tendermint-rpc/src/tendermint34/tendermint34client.spec.ts
@@ -104,9 +104,9 @@ function defaultTestSuite(rpcFactory: () => RpcClient, expected: ExpectedValues)
     expect(response).toBeTruthy();
     expect(response.commit.signatures.length).toBeGreaterThanOrEqual(1);
     expect(response.commit.signatures[0].blockIdFlag).toEqual(2);
-    expect(response.commit.signatures[0].validatorAddress.length).toEqual(20);
+    expect(response.commit.signatures[0].validatorAddress?.length).toEqual(20);
     expect(response.commit.signatures[0].timestamp).toBeInstanceOf(Date);
-    expect(response.commit.signatures[0].signature.length).toEqual(64);
+    expect(response.commit.signatures[0].signature?.length).toEqual(64);
 
     client.disconnect();
   });

--- a/packages/tendermint-rpc/src/types.ts
+++ b/packages/tendermint-rpc/src/types.ts
@@ -25,7 +25,7 @@ export enum BlockIdFlag {
 export interface CommitSignature {
   /** If this is BlockIdFlag.Absent, all other fields are expected to be unset */
   blockIdFlag: BlockIdFlag;
-  validatorAddress: Uint8Array;
-  timestamp?: ReadonlyDateWithNanoseconds;
-  signature: Uint8Array;
+  validatorAddress: Uint8Array | undefined;
+  timestamp: ReadonlyDateWithNanoseconds | undefined;
+  signature: Uint8Array | undefined;
 }


### PR DESCRIPTION
A little nicer API for the fix from 0.24.1