### PR TITLE
Expose registry and fee table from signing clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ### Added
 
+- @cosmjs/cosmwasm-launchpad: Expose `SigningCosmWasmClient.fees`.
+- @cosmjs/cosmwasm-stargate: Expose `SigningCosmWasmClient.fees` and
+  `SigningCosmWasmClient.registry`.
+- @cosmjs/launchpad: Expose `SigningCosmosClient.fees`.
+- @cosmjs/stargate: Expose `SigningStargateClient.fees` and
+  `SigningStargateClient.registry`.
 - @cosmjs/stargate: Add support for different account types in `accountFromAny`
   and `StargateClient`. Added `ModuleAccount` and vesting accounts
   `BaseVestingAccount`, `ContinuousVestingAccount`, `DelayedVestingAccount` and

--- a/packages/cosmwasm-launchpad/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-launchpad/src/signingcosmwasmclient.ts
@@ -149,10 +149,10 @@ export interface PrivateSigningCosmWasmClient {
 }
 
 export class SigningCosmWasmClient extends CosmWasmClient {
+  public readonly fees: CosmWasmFeeTable;
   public readonly signerAddress: string;
 
   private readonly signer: OfflineSigner;
-  private readonly fees: CosmWasmFeeTable;
 
   /**
    * Creates a new client with signing capability to interact with a CosmWasm blockchain. This is the bigger brother of CosmWasmClient.

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -108,8 +108,9 @@ export interface PrivateSigningCosmWasmClient {
 }
 
 export class SigningCosmWasmClient extends CosmWasmClient {
-  private readonly fees: CosmosFeeTable;
-  private readonly registry: Registry;
+  public readonly fees: CosmosFeeTable;
+  public readonly registry: Registry;
+
   private readonly signer: OfflineSigner;
   private readonly aminoTypes: AminoTypes;
 

--- a/packages/launchpad/src/signingcosmosclient.ts
+++ b/packages/launchpad/src/signingcosmosclient.ts
@@ -27,10 +27,10 @@ export interface PrivateSigningCosmosClient {
 }
 
 export class SigningCosmosClient extends CosmosClient {
+  public readonly fees: CosmosFeeTable;
   public readonly signerAddress: string;
 
   private readonly signer: OfflineSigner;
-  private readonly fees: CosmosFeeTable;
 
   /**
    * Creates a new client with signing capability to interact with a Cosmos SDK blockchain. This is the bigger brother of CosmosClient.

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -76,8 +76,9 @@ export interface SigningStargateClientOptions {
 }
 
 export class SigningStargateClient extends StargateClient {
-  private readonly fees: CosmosFeeTable;
-  private readonly registry: Registry;
+  public readonly fees: CosmosFeeTable;
+  public readonly registry: Registry;
+
   private readonly signer: OfflineSigner;
   private readonly aminoTypes: AminoTypes;
 


### PR DESCRIPTION
Closes #628

I also exposed the fee table because they’re readonly anyway and it might be useful to see the fees.

