### PR TITLE
Move prettier config for markdown to config

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,13 @@
 {
   "printWidth": 110,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "printWidth": 80,
+        "proseWrap": "always"
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "format": "lerna run format",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\" && lerna run format-text",
+    "format-text": "prettier --write \"./*.md\" && lerna run format-text",
     "format-shell": "shfmt -w scripts packages",
     "lint": "lerna run lint",
     "lint-fix": "lerna run lint-fix",

--- a/packages/amino/package.json
+++ b/packages/amino/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "prebuild": "shx rm -rf ./build",

--- a/packages/cosmwasm-launchpad/package.json
+++ b/packages/cosmwasm-launchpad/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "docs": "typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "prebuild": "shx rm -rf ./build",

--- a/packages/cosmwasm-stargate/package.json
+++ b/packages/cosmwasm-stargate/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "docs": "typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "prebuild": "shx rm -rf ./build",

--- a/packages/cosmwasm/package.json
+++ b/packages/cosmwasm/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "docs": "typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "prebuild": "shx rm -rf ./build",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",

--- a/packages/encoding/package.json
+++ b/packages/encoding/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",

--- a/packages/faucet-client/package.json
+++ b/packages/faucet-client/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",

--- a/packages/faucet/package.json
+++ b/packages/faucet/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "dev-start": "yarn start-dev",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "prebuild": "shx rm -rf ./build",

--- a/packages/json-rpc/package.json
+++ b/packages/json-rpc/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "docs": "typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "prebuild": "shx rm -rf ./build",

--- a/packages/ledger-amino/package.json
+++ b/packages/ledger-amino/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "docs": "typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "prebuild": "shx rm -rf ./build",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",

--- a/packages/proto-signing/package.json
+++ b/packages/proto-signing/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "docs": "typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "prebuild": "shx rm -rf ./build",

--- a/packages/socket/package.json
+++ b/packages/socket/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",

--- a/packages/stargate/package.json
+++ b/packages/stargate/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "docs": "typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "prebuild": "shx rm -rf ./build",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",

--- a/packages/tendermint-rpc/package.json
+++ b/packages/tendermint-rpc/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "docs": "typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
+    "format-text": "prettier --write \"./*.md\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\"",
     "lint-fix": "eslint --max-warnings 0 \"**/*.{js,ts}\" --fix",
     "prebuild": "shx rm -rf ./build",


### PR DESCRIPTION
With this change, different prettier tools get the chance to produce the same result. This helps us with IDE plugins.