### PR TITLE
Remove named capture groups from regexes

### DIFF
--- a/packages/launchpad/src/fee.ts
+++ b/packages/launchpad/src/fee.ts
@@ -13,11 +13,11 @@ export class GasPrice {
   }
 
   public static fromString(gasPrice: string): GasPrice {
-    const matchResult = gasPrice.match(/^(?<amount>.+?)(?<denom>[a-z]+)$/);
+    const matchResult = gasPrice.match(/^(\d*\.?\d*)([a-z]+)$/);
     if (!matchResult) {
       throw new Error("Invalid gas price string");
     }
-    const { amount, denom } = matchResult.groups as { readonly amount: string; readonly denom: string };
+    const [, amount, denom] = matchResult;
     if (denom.length < 3 || denom.length > 127) {
       throw new Error("Gas price denomination must be between 3 and 127 characters");
     }

--- a/packages/stargate/src/fee.ts
+++ b/packages/stargate/src/fee.ts
@@ -20,11 +20,11 @@ export class GasPrice {
   }
 
   public static fromString(gasPrice: string): GasPrice {
-    const matchResult = gasPrice.match(/^(?<amount>.+?)(?<denom>[a-z]+)$/);
+    const matchResult = gasPrice.match(/^(\d*\.?\d*)([a-z]+)$/);
     if (!matchResult) {
       throw new Error("Invalid gas price string");
     }
-    const { amount, denom } = matchResult.groups as { readonly amount: string; readonly denom: string };
+    const [, amount, denom] = matchResult;
     if (denom.length < 3 || denom.length > 127) {
       throw new Error("Gas price denomination must be between 3 and 127 characters");
     }


### PR DESCRIPTION
Documented a little bit of my investigation in [this](https://github.com/cosmos/cosmjs/issues/801) ticket. Basically we need Hermes compatibility as we're building a React Native application and are using this library.

All the tests pass on my machine 👍 and as a side note I learned that the plural of regex is not in fact regices 🤷‍♂️