### PR TITLE
Avoid the use of es2018 named capture groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,13 @@ and this project adheres to
   `CosmWasmClient.broadcastTx` and `StargateClient.broadcastTx` ([#800]). This
   bug was introduced with the switch from broadcast mode "commit" to "sync" in
   version 0.25.0.
+- @cosmjs/launchpad, @cosmjs/stargate: Avoid the use of named capture groups in
+  `GasPrice.fromString` to restore ES2017 compatibility and make the library
+  work with Hermes ([#801]; thanks [@AlexBHarley]).
 
 [#800]: https://github.com/cosmos/cosmjs/issues/800
+[#801]: https://github.com/cosmos/cosmjs/issues/801
+[@alexbharley]: https://github.com/AlexBHarley
 
 ## [0.25.2] - 2021-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   work with Hermes ([#801]; thanks [@AlexBHarley]).
 - @cosmjs/launchpad: Adapt `GasPrice.fromString` denom pattern to Cosmos SDK
   0.39 rules: reduce denom length to 16 and allow digits in denom.
+- @cosmjs/stargate: Adapt `GasPrice.fromString` denom pattern to Cosmos SDK 0.42
+  rules: allow lengths up to 128, allow upper case letters and digits.
 
 [#800]: https://github.com/cosmos/cosmjs/issues/800
 [#801]: https://github.com/cosmos/cosmjs/issues/801

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 - @cosmjs/launchpad, @cosmjs/stargate: Avoid the use of named capture groups in
   `GasPrice.fromString` to restore ES2017 compatibility and make the library
   work with Hermes ([#801]; thanks [@AlexBHarley]).
+- @cosmjs/launchpad: Adapt `GasPrice.fromString` denom pattern to Cosmos SDK
+  0.39 rules: reduce denom length to 16 and allow digits in denom.
 
 [#800]: https://github.com/cosmos/cosmjs/issues/800
 [#801]: https://github.com/cosmos/cosmjs/issues/801

--- a/packages/launchpad/src/fee.spec.ts
+++ b/packages/launchpad/src/fee.spec.ts
@@ -12,12 +12,38 @@ describe("GasPrice", () => {
     });
   });
 
-  it("can be constructed from a config string", () => {
-    const inputs = ["3.14", "3", "0.14"];
-    inputs.forEach((input) => {
-      const gasPrice = GasPrice.fromString(`${input}utest`);
-      expect(gasPrice.amount.toString()).toEqual(input);
-      expect(gasPrice.denom).toEqual("utest");
+  describe("fromString", () => {
+    it("works", () => {
+      const inputs = ["3.14", "3", "0.14"];
+      inputs.forEach((input) => {
+        const gasPrice = GasPrice.fromString(`${input}utest`);
+        expect(gasPrice.amount.toString()).toEqual(input);
+        expect(gasPrice.denom).toEqual("utest");
+      });
+    });
+
+    it("errors for invalid gas price", () => {
+      // Checks basic format <amount><denom>
+      expect(() => GasPrice.fromString("")).toThrowError(/Invalid gas price string/i);
+      expect(() => GasPrice.fromString("utkn")).toThrowError(/Invalid gas price string/i);
+      expect(() => GasPrice.fromString("@utkn")).toThrowError(/Invalid gas price string/i);
+      expect(() => GasPrice.fromString("234")).toThrowError(/Invalid gas price string/i);
+      expect(() => GasPrice.fromString("-234tkn")).toThrowError(/Invalid gas price string/i);
+      // Checks details of <denom>
+      expect(() => GasPrice.fromString("234t")).toThrowError(
+        /denomination must be between 3 and 127 characters/i,
+      );
+      expect(() => GasPrice.fromString("234tt")).toThrowError(
+        /denomination must be between 3 and 127 characters/i,
+      );
+      expect(() =>
+        GasPrice.fromString(
+          "234tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt",
+        ),
+      ).toThrowError(/denomination must be between 3 and 127 characters/i);
+      // Checks details of <amount>
+      expect(() => GasPrice.fromString("3.utkn")).toThrowError(/Fractional part missing/i);
+      expect(() => GasPrice.fromString("..utkn")).toThrowError(/More than one separator found/i);
     });
   });
 });

--- a/packages/launchpad/src/fee.spec.ts
+++ b/packages/launchpad/src/fee.spec.ts
@@ -14,12 +14,21 @@ describe("GasPrice", () => {
 
   describe("fromString", () => {
     it("works", () => {
-      const inputs = ["3.14", "3", "0.14"];
-      inputs.forEach((input) => {
-        const gasPrice = GasPrice.fromString(`${input}utest`);
-        expect(gasPrice.amount.toString()).toEqual(input);
-        expect(gasPrice.denom).toEqual("utest");
-      });
+      const inputs: Record<string, { amount: string; denom: string }> = {
+        // Test amounts
+        "3.14utest": { amount: "3.14", denom: "utest" },
+        "3utest": { amount: "3", denom: "utest" },
+        "0.14utest": { amount: "0.14", denom: "utest" },
+        // Test denoms
+        "0.14sht": { amount: "0.14", denom: "sht" },
+        "0.14testtesttesttest": { amount: "0.14", denom: "testtesttesttest" },
+        "0.14ucoin2": { amount: "0.14", denom: "ucoin2" },
+      };
+      for (const [input, expected] of Object.entries(inputs)) {
+        const gasPrice = GasPrice.fromString(input);
+        expect(gasPrice.amount.toString()).withContext(`Input: ${input}`).toEqual(expected.amount);
+        expect(gasPrice.denom).withContext(`Input: ${input}`).toEqual(expected.denom);
+      }
     });
 
     it("errors for invalid gas price", () => {
@@ -30,17 +39,14 @@ describe("GasPrice", () => {
       expect(() => GasPrice.fromString("234")).toThrowError(/Invalid gas price string/i);
       expect(() => GasPrice.fromString("-234tkn")).toThrowError(/Invalid gas price string/i);
       // Checks details of <denom>
-      expect(() => GasPrice.fromString("234t")).toThrowError(
-        /denomination must be between 3 and 127 characters/i,
+      expect(() => GasPrice.fromString("234t")).toThrowError(/denom must be between 3 and 16 characters/i);
+      expect(() => GasPrice.fromString("234tt")).toThrowError(/denom must be between 3 and 16 characters/i);
+      expect(() => GasPrice.fromString("234ttttttttttttttttt")).toThrowError(
+        /denom must be between 3 and 16 characters/i,
       );
-      expect(() => GasPrice.fromString("234tt")).toThrowError(
-        /denomination must be between 3 and 127 characters/i,
+      expect(() => GasPrice.fromString("234ATOM")).toThrowError(
+        /denom must only contain lower case letters a-z and digits 0-9/i,
       );
-      expect(() =>
-        GasPrice.fromString(
-          "234tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt",
-        ),
-      ).toThrowError(/denomination must be between 3 and 127 characters/i);
       // Checks details of <amount>
       expect(() => GasPrice.fromString("3.utkn")).toThrowError(/Fractional part missing/i);
       expect(() => GasPrice.fromString("..utkn")).toThrowError(/More than one separator found/i);

--- a/packages/launchpad/src/fee.ts
+++ b/packages/launchpad/src/fee.ts
@@ -13,7 +13,7 @@ export class GasPrice {
   }
 
   public static fromString(gasPrice: string): GasPrice {
-    const matchResult = gasPrice.match(/^(?<amount>.+?)(?<denom>[a-z]+)$/);
+    const matchResult = gasPrice.match(/^(?<amount>[0-9.]+?)(?<denom>[a-z]+)$/);
     if (!matchResult) {
       throw new Error("Invalid gas price string");
     }

--- a/packages/launchpad/src/fee.ts
+++ b/packages/launchpad/src/fee.ts
@@ -3,6 +3,10 @@ import { Decimal, Uint53 } from "@cosmjs/math";
 
 export type FeeTable = Record<string, StdFee>;
 
+/**
+ * A gas price, i.e. the price of a single gas. This is typically a fraction of
+ * the smallest fee token unit, such as 0.012utoken.
+ */
 export class GasPrice {
   public readonly amount: Decimal;
   public readonly denom: string;
@@ -12,6 +16,9 @@ export class GasPrice {
     this.denom = denom;
   }
 
+  /**
+   * Parses a gas price formatted as `<amount><denom>`, e.g. `GasPrice.fromString("0.012utoken")`.
+   */
   public static fromString(gasPrice: string): GasPrice {
     const matchResult = gasPrice.match(/^([0-9.]+?)([a-z]+)$/);
     if (!matchResult) {

--- a/packages/launchpad/src/fee.ts
+++ b/packages/launchpad/src/fee.ts
@@ -4,6 +4,21 @@ import { Decimal, Uint53 } from "@cosmjs/math";
 export type FeeTable = Record<string, StdFee>;
 
 /**
+ * Denom checker for the Cosmos SDK 0.39 denom pattern
+ * (https://github.com/cosmos/cosmos-sdk/blob/v0.39.3/types/coin.go#L597-L598).
+ *
+ * This is like a regexp but with helpful error messages.
+ */
+function checkDenom(denom: string): void {
+  if (denom.length < 3 || denom.length > 16) {
+    throw new Error("Denom must be between 3 and 16 characters");
+  }
+  if (denom.match(/[^a-z0-9]/)) {
+    throw new Error("Denom must only contain lower case letters a-z and digits 0-9");
+  }
+}
+
+/**
  * A gas price, i.e. the price of a single gas. This is typically a fraction of
  * the smallest fee token unit, such as 0.012utoken.
  */
@@ -18,16 +33,18 @@ export class GasPrice {
 
   /**
    * Parses a gas price formatted as `<amount><denom>`, e.g. `GasPrice.fromString("0.012utoken")`.
+   *
+   * The denom must match the Cosmos SDK 0.39 pattern (https://github.com/cosmos/cosmos-sdk/blob/v0.39.3/types/coin.go#L597-L598).
+   * See `GasPrice` in @cosmjs/stargate for a more generic matcher.
    */
   public static fromString(gasPrice: string): GasPrice {
-    const matchResult = gasPrice.match(/^([0-9.]+?)([a-z]+)$/);
+    // Use Decimal.fromUserInput and checkDenom for detailed checks and helpful error messages
+    const matchResult = gasPrice.match(/^([0-9.]+)([a-z][a-z0-9]*)$/i);
     if (!matchResult) {
       throw new Error("Invalid gas price string");
     }
     const [_, amount, denom] = matchResult;
-    if (denom.length < 3 || denom.length > 127) {
-      throw new Error("Gas price denomination must be between 3 and 127 characters");
-    }
+    checkDenom(denom);
     const fractionalDigits = 18;
     const decimalAmount = Decimal.fromUserInput(amount, fractionalDigits);
     return new GasPrice(decimalAmount, denom);

--- a/packages/launchpad/src/fee.ts
+++ b/packages/launchpad/src/fee.ts
@@ -13,11 +13,11 @@ export class GasPrice {
   }
 
   public static fromString(gasPrice: string): GasPrice {
-    const matchResult = gasPrice.match(/^(?<amount>[0-9.]+?)(?<denom>[a-z]+)$/);
+    const matchResult = gasPrice.match(/^([0-9.]+?)([a-z]+)$/);
     if (!matchResult) {
       throw new Error("Invalid gas price string");
     }
-    const { amount, denom } = matchResult.groups as { readonly amount: string; readonly denom: string };
+    const [_, amount, denom] = matchResult;
     if (denom.length < 3 || denom.length > 127) {
       throw new Error("Gas price denomination must be between 3 and 127 characters");
     }

--- a/packages/launchpad/src/fee.ts
+++ b/packages/launchpad/src/fee.ts
@@ -19,7 +19,7 @@ function checkDenom(denom: string): void {
 }
 
 /**
- * A gas price, i.e. the price of a single gas. This is typically a fraction of
+ * A gas price, i.e. the price of a single unit of gas. This is typically a fraction of
  * the smallest fee token unit, such as 0.012utoken.
  */
 export class GasPrice {

--- a/packages/stargate/src/fee.spec.ts
+++ b/packages/stargate/src/fee.spec.ts
@@ -12,12 +12,38 @@ describe("GasPrice", () => {
     });
   });
 
-  it("can be constructed from a config string", () => {
-    const inputs = ["3.14", "3", "0.14"];
-    inputs.forEach((input) => {
-      const gasPrice = GasPrice.fromString(`${input}utest`);
-      expect(gasPrice.amount.toString()).toEqual(input);
-      expect(gasPrice.denom).toEqual("utest");
+  describe("fromString", () => {
+    it("works", () => {
+      const inputs = ["3.14", "3", "0.14"];
+      inputs.forEach((input) => {
+        const gasPrice = GasPrice.fromString(`${input}utest`);
+        expect(gasPrice.amount.toString()).toEqual(input);
+        expect(gasPrice.denom).toEqual("utest");
+      });
+    });
+
+    it("errors for invalid gas price", () => {
+      // Checks basic format <amount><denom>
+      expect(() => GasPrice.fromString("")).toThrowError(/Invalid gas price string/i);
+      expect(() => GasPrice.fromString("utkn")).toThrowError(/Invalid gas price string/i);
+      expect(() => GasPrice.fromString("@utkn")).toThrowError(/Invalid gas price string/i);
+      expect(() => GasPrice.fromString("234")).toThrowError(/Invalid gas price string/i);
+      expect(() => GasPrice.fromString("-234tkn")).toThrowError(/Invalid gas price string/i);
+      // Checks details of <denom>
+      expect(() => GasPrice.fromString("234t")).toThrowError(
+        /denomination must be between 3 and 127 characters/i,
+      );
+      expect(() => GasPrice.fromString("234tt")).toThrowError(
+        /denomination must be between 3 and 127 characters/i,
+      );
+      expect(() =>
+        GasPrice.fromString(
+          "234tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt",
+        ),
+      ).toThrowError(/denomination must be between 3 and 127 characters/i);
+      // Checks details of <amount>
+      expect(() => GasPrice.fromString("3.utkn")).toThrowError(/Fractional part missing/i);
+      expect(() => GasPrice.fromString("..utkn")).toThrowError(/More than one separator found/i);
     });
   });
 });

--- a/packages/stargate/src/fee.spec.ts
+++ b/packages/stargate/src/fee.spec.ts
@@ -14,12 +14,27 @@ describe("GasPrice", () => {
 
   describe("fromString", () => {
     it("works", () => {
-      const inputs = ["3.14", "3", "0.14"];
-      inputs.forEach((input) => {
-        const gasPrice = GasPrice.fromString(`${input}utest`);
-        expect(gasPrice.amount.toString()).toEqual(input);
-        expect(gasPrice.denom).toEqual("utest");
-      });
+      const inputs: Record<string, { amount: string; denom: string }> = {
+        // Test amounts
+        "3.14utest": { amount: "3.14", denom: "utest" },
+        "3utest": { amount: "3", denom: "utest" },
+        "0.14utest": { amount: "0.14", denom: "utest" },
+        // Test denoms
+        "0.14sht": { amount: "0.14", denom: "sht" },
+        "0.14testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest": {
+          amount: "0.14",
+          denom:
+            "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest",
+        },
+        "0.14ucoin2": { amount: "0.14", denom: "ucoin2" },
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        "0.14FOOBAR": { amount: "0.14", denom: "FOOBAR" },
+      };
+      for (const [input, expected] of Object.entries(inputs)) {
+        const gasPrice = GasPrice.fromString(input);
+        expect(gasPrice.amount.toString()).withContext(`Input: ${input}`).toEqual(expected.amount);
+        expect(gasPrice.denom).withContext(`Input: ${input}`).toEqual(expected.denom);
+      }
     });
 
     it("errors for invalid gas price", () => {
@@ -30,17 +45,13 @@ describe("GasPrice", () => {
       expect(() => GasPrice.fromString("234")).toThrowError(/Invalid gas price string/i);
       expect(() => GasPrice.fromString("-234tkn")).toThrowError(/Invalid gas price string/i);
       // Checks details of <denom>
-      expect(() => GasPrice.fromString("234t")).toThrowError(
-        /denomination must be between 3 and 127 characters/i,
-      );
-      expect(() => GasPrice.fromString("234tt")).toThrowError(
-        /denomination must be between 3 and 127 characters/i,
-      );
+      expect(() => GasPrice.fromString("234t")).toThrowError(/denom must be between 3 and 128 characters/i);
+      expect(() => GasPrice.fromString("234tt")).toThrowError(/denom must be between 3 and 128 characters/i);
       expect(() =>
         GasPrice.fromString(
-          "234tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt",
+          "234ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt",
         ),
-      ).toThrowError(/denomination must be between 3 and 127 characters/i);
+      ).toThrowError(/denom must be between 3 and 128 characters/i);
       // Checks details of <amount>
       expect(() => GasPrice.fromString("3.utkn")).toThrowError(/Fractional part missing/i);
       expect(() => GasPrice.fromString("..utkn")).toThrowError(/More than one separator found/i);

--- a/packages/stargate/src/fee.ts
+++ b/packages/stargate/src/fee.ts
@@ -20,7 +20,7 @@ function checkDenom(denom: string): void {
 }
 
 /**
- * A gas price, i.e. the price of a single gas. This is typically a fraction of
+ * A gas price, i.e. the price of a single unit of gas. This is typically a fraction of
  * the smallest fee token unit, such as 0.012utoken.
  *
  * This is the same as GasPrice from @cosmjs/launchpad but those might diverge in the future.

--- a/packages/stargate/src/fee.ts
+++ b/packages/stargate/src/fee.ts
@@ -20,7 +20,7 @@ export class GasPrice {
   }
 
   public static fromString(gasPrice: string): GasPrice {
-    const matchResult = gasPrice.match(/^(?<amount>.+?)(?<denom>[a-z]+)$/);
+    const matchResult = gasPrice.match(/^(?<amount>[0-9.]+?)(?<denom>[a-z]+)$/);
     if (!matchResult) {
       throw new Error("Invalid gas price string");
     }

--- a/packages/stargate/src/fee.ts
+++ b/packages/stargate/src/fee.ts
@@ -8,6 +8,9 @@ import { coins } from "@cosmjs/proto-signing";
 export type FeeTable = Record<string, StdFee>;
 
 /**
+ * A gas price, i.e. the price of a single gas. This is typically a fraction of
+ * the smallest fee token unit, such as 0.012utoken.
+ *
  * This is the same as GasPrice from @cosmjs/launchpad but those might diverge in the future.
  */
 export class GasPrice {
@@ -19,6 +22,9 @@ export class GasPrice {
     this.denom = denom;
   }
 
+  /**
+   * Parses a gas price formatted as `<amount><denom>`, e.g. `GasPrice.fromString("0.012utoken")`.
+   */
   public static fromString(gasPrice: string): GasPrice {
     const matchResult = gasPrice.match(/^([0-9.]+?)([a-z]+)$/);
     if (!matchResult) {

--- a/packages/stargate/src/fee.ts
+++ b/packages/stargate/src/fee.ts
@@ -20,11 +20,11 @@ export class GasPrice {
   }
 
   public static fromString(gasPrice: string): GasPrice {
-    const matchResult = gasPrice.match(/^(?<amount>[0-9.]+?)(?<denom>[a-z]+)$/);
+    const matchResult = gasPrice.match(/^([0-9.]+?)([a-z]+)$/);
     if (!matchResult) {
       throw new Error("Invalid gas price string");
     }
-    const { amount, denom } = matchResult.groups as { readonly amount: string; readonly denom: string };
+    const [_, amount, denom] = matchResult;
     if (denom.length < 3 || denom.length > 127) {
       throw new Error("Gas price denomination must be between 3 and 127 characters");
     }


### PR DESCRIPTION
Names capture groups are an ES2018 feature that [TS does not transpile down](https://github.com/microsoft/TypeScript/issues/36132) to our current target ES2017. We don't need it much so we can easily work around it.

Closes #801
Closes #802