### PR TITLE
Remove stray block search code from Tendermint 0.33 client

### DIFF
--- a/packages/tendermint-rpc/src/tendermint33/adaptor/requests.ts
+++ b/packages/tendermint-rpc/src/tendermint33/adaptor/requests.ts
@@ -30,21 +30,6 @@ function encodeBlockchainRequestParams(param: requests.BlockchainRequestParams):
   };
 }
 
-interface RpcBlockSearchParams {
-  readonly query: string;
-  readonly page?: string;
-  readonly per_page?: string;
-  readonly order_by?: string;
-}
-function encodeBlockSearchParams(params: requests.BlockSearchParams): RpcBlockSearchParams {
-  return {
-    query: params.query,
-    page: may(Integer.encode, params.page),
-    per_page: may(Integer.encode, params.per_page),
-    order_by: params.order_by,
-  };
-}
-
 interface RpcAbciQueryParams {
   readonly path: string;
   /** hex encoded */
@@ -133,10 +118,6 @@ export class Params {
 
   public static encodeBlockResults(req: requests.BlockResultsRequest): JsonRpcRequest {
     return createJsonRpcRequest(req.method, encodeHeightParam(req.params));
-  }
-
-  public static encodeBlockSearch(req: requests.BlockSearchRequest): JsonRpcRequest {
-    return createJsonRpcRequest(req.method, encodeBlockSearchParams(req.params));
   }
 
   public static encodeBroadcastTx(req: requests.BroadcastTxRequest): JsonRpcRequest {


### PR DESCRIPTION
The block search functionality is imly implemented for Tendermint 0.34.

No idea how those code made it into main. Probably some kind of strange merge conflict. 