### PR TITLE
Update SigningCosmWasmClient.execute to accept multiple messages

### DIFF
--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -339,21 +339,21 @@ export class SigningCosmWasmClient extends CosmWasmClient {
   public async execute(
     senderAddress: string,
     contractAddress: string,
-    msg: Record<string, unknown>,
+    msgs: Array<Record<string, unknown>>,
     fee: StdFee,
     memo = "",
     funds?: readonly Coin[],
   ): Promise<ExecuteResult> {
-    const executeContractMsg: MsgExecuteContractEncodeObject = {
+    const executeContractMsgs: Array<MsgExecuteContractEncodeObject> = msgs.map((m) => {return {
       typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
       value: MsgExecuteContract.fromPartial({
         sender: senderAddress,
         contract: contractAddress,
-        msg: toUtf8(JSON.stringify(msg)),
+        msg: toUtf8(JSON.stringify(m)),
         funds: [...(funds || [])],
       }),
-    };
-    const result = await this.signAndBroadcast(senderAddress, [executeContractMsg], fee, memo);
+    }});
+    const result = await this.signAndBroadcast(senderAddress, [executeContractMsgs], fee, memo);
     if (isBroadcastTxFailure(result)) {
       throw new Error(createBroadcastTxErrorMessage(result));
     }


### PR DESCRIPTION
Proposing a change to the inputs of `SigningCosmWasmClient.execute` to accept multiple transactions. I think this functionality is important to expose and altering the input to an array is the cleanest implementation.

If we want to avoid introducing breaking change this could be implemented with execute msg having the type of `Record<string, unknown> |   Array<Record<string, unknown>>` or as a separate function, ie `SigningCosmWasmClient.executeMultiple`. 

Would love to discuss! I have been signing multi-msg transactions with `SigningCosmWasmClient.signAndBroadcast` directly and it is quite unergonomic. 