### PR TITLE
Add custom ledger app name support

### DIFF
--- a/packages/ledger-amino/src/launchpadledger.ts
+++ b/packages/ledger-amino/src/launchpadledger.ts
@@ -24,7 +24,7 @@ function unharden(hdPath: HdPath): number[] {
 
 const cosmosHdPath = makeCosmoshubPath(0);
 const cosmosBech32Prefix = "cosmos";
-const cosmosLedgerAppName = "cosmos";
+const cosmosLedgerAppName = "Cosmos";
 const requiredCosmosAppVersion = "1.5.3";
 
 export interface LaunchpadLedgerOptions {

--- a/packages/ledger-amino/src/launchpadledger.ts
+++ b/packages/ledger-amino/src/launchpadledger.ts
@@ -24,18 +24,21 @@ function unharden(hdPath: HdPath): number[] {
 
 const cosmosHdPath = makeCosmoshubPath(0);
 const cosmosBech32Prefix = "cosmos";
+const cosmosLedgerAppName = "cosmos";
 const requiredCosmosAppVersion = "1.5.3";
 
 export interface LaunchpadLedgerOptions {
   readonly hdPaths?: readonly HdPath[];
   readonly prefix?: string;
   readonly testModeAllowed?: boolean;
+  readonly ledgerAppName?: string
 }
 
 export class LaunchpadLedger {
   private readonly testModeAllowed: boolean;
   private readonly hdPaths: readonly HdPath[];
   private readonly prefix: string;
+  private readonly ledgerAppName: string;
   private readonly app: CosmosApp;
 
   public constructor(transport: Transport, options: LaunchpadLedgerOptions = {}) {
@@ -43,11 +46,13 @@ export class LaunchpadLedger {
       hdPaths: [cosmosHdPath],
       prefix: cosmosBech32Prefix,
       testModeAllowed: false,
+      ledgerAppName: cosmosLedgerAppName
     };
 
     this.testModeAllowed = options.testModeAllowed ?? defaultOptions.testModeAllowed;
     this.hdPaths = options.hdPaths ?? defaultOptions.hdPaths;
     this.prefix = options.prefix ?? defaultOptions.prefix;
+    this.ledgerAppName = options.ledgerAppName ?? defaultOptions.ledgerAppName
     this.app = new CosmosApp(transport);
   }
 
@@ -125,8 +130,8 @@ export class LaunchpadLedger {
     if (appName.toLowerCase() === `dashboard`) {
       throw new Error(`Please open the Cosmos Ledger app on your Ledger device.`);
     }
-    if (appName.toLowerCase() !== `cosmos`) {
-      throw new Error(`Please close ${appName} and open the Cosmos Ledger app on your Ledger device.`);
+    if (appName.toLowerCase() !== this.ledgerAppName.toLowerCase()) {
+      throw new Error(`Please close ${appName} and open the ${this.ledgerAppName} Ledger app on your Ledger device.`);
     }
   }
 


### PR DESCRIPTION
Currently LaunchpadLedger forces users to use Cosmos ledger app. However there are cosmos-sdk based chains uses their own ledger app as they have different coin type (eg, Band, Terra, Kava, Desmos)

This PR solves the problem by allowing users to input an option `ledgerAppName` to pass the ledger app name check