### PR TITLE
Use Buffer from module

### DIFF
--- a/packages/crypto/src/ripemd.ts
+++ b/packages/crypto/src/ripemd.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import RIPEMD160 from "ripemd160";
 
 import { HashFunction } from "./hash";


### PR DESCRIPTION
When I try to use some of the cosmjs crypto libraries in the browser, not in node, the RIPEMD hash function doesn't work.

```
(node:54788) [MODULE_NOT_FOUND] Error: ripemd160 tried to access buffer. While this module is usually interpreted as a Node builtin, your resolver is running inside a non-Node resolution context where such builtins are ignored. Since buffer isn't otherwise declared in ripemd160's dependencies, this makes the require call ambiguous and unsound.
```

Using this solution here fixed it:  https://stackoverflow.com/a/55226877/3299736