### PR TITLE
Add type ID/type URL to error messages in AminoTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to
   JavaScript objects and the JSON representation of `cosmwasm_std::Binary`
   (base64).
 
+### Changed
+
+- @cosmjs/stargate: The error messages for missing types in `AminoTypes` now
+  contain the type that was searched for ([#990]).
+
+[#990]: https://github.com/cosmos/cosmjs/pull/990
+
 ## [0.27.0] - 2022-01-10
 
 ### Added

--- a/packages/stargate/src/aminotypes.spec.ts
+++ b/packages/stargate/src/aminotypes.spec.ts
@@ -569,7 +569,7 @@ describe("AminoTypes", () => {
 
     it("throws for unknown type url", () => {
       expect(() => new AminoTypes().toAmino({ typeUrl: "/xxx.Unknown", value: { foo: "bar" } })).toThrowError(
-        /Type URL does not exist in the Amino message type register./i,
+        /Type URL '\/xxx\.Unknown' does not exist in the Amino message type register./i,
       );
     });
   });
@@ -1005,7 +1005,9 @@ describe("AminoTypes", () => {
     it("throws for unknown type url", () => {
       expect(() =>
         new AminoTypes().fromAmino({ type: "cosmos-sdk/MsgUnknown", value: { foo: "bar" } }),
-      ).toThrowError(/Type does not exist in the Amino message type register./i);
+      ).toThrowError(
+        /Amino type identifier 'cosmos-sdk\/MsgUnknown' does not exist in the Amino message type register./i,
+      );
     });
   });
 });

--- a/packages/stargate/src/aminotypes.ts
+++ b/packages/stargate/src/aminotypes.ts
@@ -539,7 +539,7 @@ export class AminoTypes {
     const converter = this.register[typeUrl];
     if (!converter) {
       throw new Error(
-        "Type URL does not exist in the Amino message type register. " +
+        `Type URL '${typeUrl}' does not exist in the Amino message type register. ` +
           "If you need support for this message type, you can pass in additional entries to the AminoTypes constructor. " +
           "If you think this message type should be included by default, please open an issue at https://github.com/cosmos/cosmjs/issues.",
       );
@@ -554,7 +554,7 @@ export class AminoTypes {
     const result = Object.entries(this.register).find(([_typeUrl, { aminoType }]) => aminoType === type);
     if (!result) {
       throw new Error(
-        "Type does not exist in the Amino message type register. " +
+        `Amino type identifier '${type}' does not exist in the Amino message type register. ` +
           "If you need support for this message type, you can pass in additional entries to the AminoTypes constructor. " +
           "If you think this message type should be included by default, please open an issue at https://github.com/cosmos/cosmjs/issues.",
       );


### PR DESCRIPTION
I now saw the error message 2x in different projects where it propagated to the UI. Without the search type it is very hard to debug from screenshots what went wrong. With this, you get a much better clue what the app tried to achieve.