### PR TITLE
Bump target to ES2018

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ### Changed
 
+- all: The TypeScript compilation target is now ES2018.
 - @cosmjs/stargate: The `AminoTypes` now always requires an argument of type
   `AminoTypesOptions`. This is an object with a required `prefix` field. Before
   the prefix defaulted to "cosmos" but this is almost never the right choice for

--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ Currently the codebase supports the following runtime environments:
    [Edge Spartan](https://en.wikipedia.org/wiki/Microsoft_Edge#Development))
 3. Browser extensions (Chromium/Firefox)
 
-Our current JavaScript target standard is ES2017, giving us native async/await
-support. We use WebAssembly to implement certain cryptographic functions.
+Our current JavaScript target standard is ES2018. We use WebAssembly to
+implement certain cryptographic functions.
 
 We're happy to adjust this list according to users' needs as long as you don't
 ask for Internet Explorer support. If your environment does not support Wasm, we
-can work on a solution with swapable implementations.
+can work on a solution with swappable implementations.
 
 ## Roadmap
 

--- a/packages/cli/tsconfig_repl.json
+++ b/packages/cli/tsconfig_repl.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es2017",
+    "target": "es2018",
     "noUnusedLocals": false,
     "noImplicitAny": false
   }

--- a/packages/json-rpc/src/compatibility.ts
+++ b/packages/json-rpc/src/compatibility.ts
@@ -67,7 +67,5 @@ export function isJsonCompatibleDictionary(data: unknown): data is JsonCompatibl
     return false;
   }
 
-  // TODO: replace with Object.values when available (ES2017+)
-  const values = Object.getOwnPropertyNames(data).map((key) => (data as any)[key]);
-  return values.every(isJsonCompatibleValue);
+  return Object.values(data).every(isJsonCompatibleValue);
 }

--- a/packages/ledger-amino/tsconfig.json
+++ b/packages/ledger-amino/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": ".",
     "outDir": "build",
     "rootDir": "src",
-    "lib": ["es2017", "dom"]
+    "lib": ["es2018", "dom"]
   },
   "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es2017"],
+    "lib": ["es2018"],
+    "target": "es2018",
     "module": "commonjs",
     "moduleResolution": "node",
     "newLine": "LF",
@@ -18,7 +19,6 @@
     "removeComments": false,
     "resolveJsonModule": true,
     "sourceMap": true,
-    "strict": true,
-    "target": "es2017"
+    "strict": true
   }
 }


### PR DESCRIPTION
Intitialle created to address #1002, but it is an intermediate step now.

We cannot move to es2020 without dropping Node.js 12. Going for es2018 for now.