### PR TITLE
Update Block Interface to make evidence non-optional

### DIFF
--- a/packages/tendermint-rpc/src/tendermint34/responses.ts
+++ b/packages/tendermint-rpc/src/tendermint34/responses.ts
@@ -227,8 +227,7 @@ export interface Block {
    */
   readonly lastCommit: Commit | null;
   readonly txs: readonly Uint8Array[];
-  // This field becomes non-optional in 0.28 (https://github.com/cosmos/cosmjs/issues/1011)
-  readonly evidence?: readonly Evidence[];
+  readonly evidence: readonly Evidence[];
 }
 
 /**


### PR DESCRIPTION
Resolves #1011 

`export type Evidence = any;` unchanged as mentioned in #980 .
