### PR TITLE
Set default gas limit for send transactions to 100k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ### Changed
 
 - all: The TypeScript compilation target is now ES2018.
+- @cosmjs/faucet: Set default value of `FAUCET_GAS_LIMIT` to 100_000 to better
+  support Cosmos SDK 0.45 chains.
 - @cosmjs/stargate: The `AminoTypes` now always requires an argument of type
   `AminoTypesOptions`. This is an object with a required `prefix` field. Before
   the prefix defaulted to "cosmos" but this is almost never the right choice for

--- a/packages/cosmwasm-stargate/src/testutils.spec.ts
+++ b/packages/cosmwasm-stargate/src/testutils.spec.ts
@@ -27,7 +27,7 @@ import { SigningCosmWasmClientOptions } from "./signingcosmwasmclient";
 import hackatom from "./testdata/contract.json";
 
 export const defaultGasPrice = GasPrice.fromString("0.025ucosm");
-export const defaultSendFee = calculateFee(200_000, defaultGasPrice);
+export const defaultSendFee = calculateFee(100_000, defaultGasPrice);
 export const defaultUploadFee = calculateFee(1_500_000, defaultGasPrice);
 export const defaultInstantiateFee = calculateFee(500_000, defaultGasPrice);
 export const defaultExecuteFee = calculateFee(200_000, defaultGasPrice);

--- a/packages/faucet/README.md
+++ b/packages/faucet/README.md
@@ -49,7 +49,7 @@ FAUCET_PORT               Port of the webserver. Defaults to 8000.
 FAUCET_MEMO               Memo for send transactions. Defaults to unset.
 FAUCET_GAS_PRICE          Gas price for transactions as a comma separated list.
                           Defaults to "0.025ucosm".
-FAUCET_GAS_LIMIT          Gas limit for send transactions. Defaults to 80000.
+FAUCET_GAS_LIMIT          Gas limit for send transactions. Defaults to 100000.
 FAUCET_MNEMONIC           Secret mnemonic that serves as the base secret for the
                           faucet HD accounts
 FAUCET_PATH_PATTERN       The pattern of BIP32 paths for the faucet accounts.

--- a/packages/faucet/src/actions/help.ts
+++ b/packages/faucet/src/actions/help.ts
@@ -22,7 +22,7 @@ FAUCET_PORT               Port of the webserver. Defaults to 8000.
 FAUCET_MEMO               Memo for send transactions. Defaults to unset.
 FAUCET_GAS_PRICE          Gas price for transactions as a comma separated list.
                           Defaults to "0.025ucosm".
-FAUCET_GAS_LIMIT          Gas limit for send transactions. Defaults to 80000.
+FAUCET_GAS_LIMIT          Gas limit for send transactions. Defaults to 100000.
 FAUCET_MNEMONIC           Secret mnemonic that serves as the base secret for the
                           faucet HD accounts
 FAUCET_PATH_PATTERN       The pattern of BIP32 paths for the faucet accounts.

--- a/packages/faucet/src/constants.ts
+++ b/packages/faucet/src/constants.ts
@@ -6,7 +6,9 @@ import { parseBankTokens } from "./tokens";
 export const binaryName = "cosmos-faucet";
 export const memo: string | undefined = process.env.FAUCET_MEMO;
 export const gasPrice = GasPrice.fromString(process.env.FAUCET_GAS_PRICE || "0.025ucosm");
-export const gasLimitSend = parseInt(process.env.FAUCET_GAS_LIMIT || "200000", 10);
+export const gasLimitSend = process.env.FAUCET_GAS_LIMIT
+  ? parseInt(process.env.FAUCET_GAS_LIMIT, 10)
+  : 100_000;
 export const concurrency: number = Number.parseInt(process.env.FAUCET_CONCURRENCY || "", 10) || 5;
 export const port: number = Number.parseInt(process.env.FAUCET_PORT || "", 10) || 8000;
 export const mnemonic: string | undefined = process.env.FAUCET_MNEMONIC;

--- a/packages/stargate/src/testutils.spec.ts
+++ b/packages/stargate/src/testutils.spec.ts
@@ -64,7 +64,7 @@ export function fromOneElementArray<T>(elements: ArrayLike<T>): T {
 }
 
 export const defaultGasPrice = GasPrice.fromString("0.025ucosm");
-export const defaultSendFee = calculateFee(80_000, defaultGasPrice);
+export const defaultSendFee = calculateFee(100_000, defaultGasPrice);
 
 export const simapp = {
   tendermintUrl: "localhost:26658",

--- a/scripts/wasmd/send_first.js
+++ b/scripts/wasmd/send_first.js
@@ -25,7 +25,7 @@ async function main() {
   const client = await SigningStargateClient.connectWithSigner(rpcUrl, wallet, { prefix: prefix });
   const recipient = Bech32.encode(prefix, Random.getBytes(20));
   const amount = coins(226644, "ucosm");
-  const fee = calculateFee(200_000, "0.025ucosm");
+  const fee = calculateFee(100_000, "0.025ucosm");
   const memo = "Ensure chain has my pubkey";
   const sendResult = await client.sendTokens(faucet.address0, recipient, amount, fee, memo);
   assertIsDeliverTxSuccess(sendResult);


### PR DESCRIPTION
Today the problem came up with an older version of CosmJS. The old gas limit of 80k is not sufficient anymore for Cosmos SDK 0.45 chains, probably because there was a change to the way storage keys are charged. In some quick tests we got 86043 gas used. So 100k is probably a good value.

This adapts parts of https://github.com/cosmos/cosmjs/pull/1028 where the value was set to 200k in some places.