### PR TITLE
Add missing runtime dependencies to proto-signing and tendermint-rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- @cosmjs/proto-signing: Add missing runtime dependencies @cosmjs/encoding and
+  @cosmjs/utils.
+- @cosmjs/tendermint-rpc: Add missing runtime dependency @cosmjs/utils.
+
 ## [0.28.0] - 2022-03-17
 
 ### Changed

--- a/packages/proto-signing/package.json
+++ b/packages/proto-signing/package.json
@@ -41,14 +41,14 @@
   "dependencies": {
     "@cosmjs/amino": "workspace:packages/amino",
     "@cosmjs/crypto": "workspace:packages/crypto",
+    "@cosmjs/encoding": "workspace:packages/encoding",
     "@cosmjs/math": "workspace:packages/math",
+    "@cosmjs/utils": "workspace:packages/utils",
     "cosmjs-types": "^0.4.0",
     "long": "^4.0.0",
     "protobufjs": "~6.10.2"
   },
   "devDependencies": {
-    "@cosmjs/encoding": "workspace:packages/encoding",
-    "@cosmjs/utils": "workspace:packages/utils",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/eslint-plugin-prettier": "^3",
     "@types/jasmine": "^3.8",

--- a/packages/tendermint-rpc/package.json
+++ b/packages/tendermint-rpc/package.json
@@ -48,12 +48,12 @@
     "@cosmjs/math": "workspace:packages/math",
     "@cosmjs/socket": "workspace:packages/socket",
     "@cosmjs/stream": "workspace:packages/stream",
+    "@cosmjs/utils": "workspace:packages/utils",
     "axios": "^0.21.2",
     "readonly-date": "^1.0.0",
     "xstream": "^11.14.0"
   },
   "devDependencies": {
-    "@cosmjs/utils": "workspace:packages/utils",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/eslint-plugin-prettier": "^3",
     "@types/jasmine": "^3.8",


### PR DESCRIPTION
At some point long time ago, those dependencies were only needed for tests. Now they are used in runtime code and need to be installed by apps.