### PR TITLE
chore: improve the extensibility of (Signing)StargateClient

### DIFF
--- a/packages/stargate/src/accounts.ts
+++ b/packages/stargate/src/accounts.ts
@@ -36,8 +36,13 @@ function accountFromBaseAccount(input: BaseAccount): Account {
 }
 
 /**
- * Takes an `Any` encoded account from the chain and extracts some common
- * `Account` information from it. This is supposed to support the most relevant
+ * Represents a generic function that takes an `Any` encoded account from the chain
+ * and extracts some common `Account` information from it.
+ */
+export type AccountParser = (any: Any) => Account;
+
+/**
+ * Basic implementation of AccountParser. This is supposed to support the most relevant
  * common Cosmos SDK account types. If you need support for exotic account types,
  * you'll need to write your own account decoder.
  */

--- a/packages/stargate/src/multisignature.spec.ts
+++ b/packages/stargate/src/multisignature.spec.ts
@@ -226,7 +226,7 @@ describe("multisignature", () => {
             sequence: signingInstruction.sequence,
             chainId: signingInstruction.chainId,
           };
-          const { bodyBytes: bb, signatures } = await signingClient.sign(
+          const { txRaw: { bodyBytes: bb, signatures } } = await signingClient.sign(
             address,
             signingInstruction.msgs,
             signingInstruction.fee,

--- a/packages/stargate/src/multisignature.spec.ts
+++ b/packages/stargate/src/multisignature.spec.ts
@@ -226,7 +226,9 @@ describe("multisignature", () => {
             sequence: signingInstruction.sequence,
             chainId: signingInstruction.chainId,
           };
-          const { txRaw: { bodyBytes: bb, signatures } } = await signingClient.sign(
+          const {
+            txRaw: { bodyBytes: bb, signatures },
+          } = await signingClient.sign(
             address,
             signingInstruction.msgs,
             signingInstruction.fee,

--- a/packages/stargate/src/signingstargateclient.spec.ts
+++ b/packages/stargate/src/signingstargateclient.spec.ts
@@ -602,7 +602,7 @@ describe("SigningStargateClient", () => {
           gas: "180000", // 180k
         };
         const memo = "Use your power wisely";
-        const {txRaw} = await client.sign(faucet.address0, [msgAny], fee, memo);
+        const { txRaw } = await client.sign(faucet.address0, [msgAny], fee, memo);
 
         // ensure signature is valid
         const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(txRaw).finish()));
@@ -632,7 +632,7 @@ describe("SigningStargateClient", () => {
           gas: "180000", // 180k
         };
         const memo = "Use your power wisely";
-        const {txRaw} = await client.sign(faucet.address0, [msgAny], fee, memo);
+        const { txRaw } = await client.sign(faucet.address0, [msgAny], fee, memo);
 
         const body = TxBody.decode(txRaw.bodyBytes);
         const authInfo = AuthInfo.decode(txRaw.authInfoBytes);
@@ -671,7 +671,7 @@ describe("SigningStargateClient", () => {
           gas: "200000",
         };
         const memo = "Use your tokens wisely";
-        const {txRaw} = await client.sign(faucet.address0, [msgAny], fee, memo);
+        const { txRaw } = await client.sign(faucet.address0, [msgAny], fee, memo);
 
         // ensure signature is valid
         const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(txRaw).finish()));
@@ -701,7 +701,7 @@ describe("SigningStargateClient", () => {
           gas: "200000",
         };
         const memo = "Use your tokens wisely";
-        const {txRaw} = await client.sign(faucet.address0, [msgAny], fee, memo);
+        const { txRaw } = await client.sign(faucet.address0, [msgAny], fee, memo);
 
         // ensure signature is valid
         const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(txRaw).finish()));
@@ -822,7 +822,7 @@ describe("SigningStargateClient", () => {
           gas: "200000",
         };
         const memo = "Use your power wisely";
-        const {txRaw} = await client.sign(faucet.address0, [msgAny], fee, memo);
+        const { txRaw } = await client.sign(faucet.address0, [msgAny], fee, memo);
 
         // ensure signature is valid
         const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(txRaw).finish()));
@@ -852,7 +852,7 @@ describe("SigningStargateClient", () => {
           gas: "200000",
         };
         const memo = "Use your power wisely";
-        const {txRaw} = await client.sign(faucet.address0, [msgAny], fee, memo);
+        const { txRaw } = await client.sign(faucet.address0, [msgAny], fee, memo);
 
         const body = TxBody.decode(txRaw.bodyBytes);
         const authInfo = AuthInfo.decode(txRaw.authInfoBytes);

--- a/packages/stargate/src/signingstargateclient.spec.ts
+++ b/packages/stargate/src/signingstargateclient.spec.ts
@@ -602,10 +602,10 @@ describe("SigningStargateClient", () => {
           gas: "180000", // 180k
         };
         const memo = "Use your power wisely";
-        const signed = await client.sign(faucet.address0, [msgAny], fee, memo);
+        const {txRaw} = await client.sign(faucet.address0, [msgAny], fee, memo);
 
         // ensure signature is valid
-        const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(signed).finish()));
+        const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(txRaw).finish()));
         assertIsDeliverTxSuccess(result);
       });
 
@@ -632,17 +632,17 @@ describe("SigningStargateClient", () => {
           gas: "180000", // 180k
         };
         const memo = "Use your power wisely";
-        const signed = await client.sign(faucet.address0, [msgAny], fee, memo);
+        const {txRaw} = await client.sign(faucet.address0, [msgAny], fee, memo);
 
-        const body = TxBody.decode(signed.bodyBytes);
-        const authInfo = AuthInfo.decode(signed.authInfoBytes);
+        const body = TxBody.decode(txRaw.bodyBytes);
+        const authInfo = AuthInfo.decode(txRaw.authInfoBytes);
         // From ModifyingDirectSecp256k1HdWallet
         expect(body.memo).toEqual("This was modified");
         expect({ ...authInfo.fee!.amount[0] }).toEqual(coin(3000, "ucosm"));
         expect(authInfo.fee!.gasLimit.toNumber()).toEqual(333333);
 
         // ensure signature is valid
-        const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(signed).finish()));
+        const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(txRaw).finish()));
         assertIsDeliverTxSuccess(result);
       });
     });
@@ -671,10 +671,10 @@ describe("SigningStargateClient", () => {
           gas: "200000",
         };
         const memo = "Use your tokens wisely";
-        const signed = await client.sign(faucet.address0, [msgAny], fee, memo);
+        const {txRaw} = await client.sign(faucet.address0, [msgAny], fee, memo);
 
         // ensure signature is valid
-        const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(signed).finish()));
+        const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(txRaw).finish()));
         assertIsDeliverTxSuccess(result);
       });
 
@@ -701,10 +701,10 @@ describe("SigningStargateClient", () => {
           gas: "200000",
         };
         const memo = "Use your tokens wisely";
-        const signed = await client.sign(faucet.address0, [msgAny], fee, memo);
+        const {txRaw} = await client.sign(faucet.address0, [msgAny], fee, memo);
 
         // ensure signature is valid
-        const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(signed).finish()));
+        const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(txRaw).finish()));
         assertIsDeliverTxSuccess(result);
       });
 
@@ -822,10 +822,10 @@ describe("SigningStargateClient", () => {
           gas: "200000",
         };
         const memo = "Use your power wisely";
-        const signed = await client.sign(faucet.address0, [msgAny], fee, memo);
+        const {txRaw} = await client.sign(faucet.address0, [msgAny], fee, memo);
 
         // ensure signature is valid
-        const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(signed).finish()));
+        const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(txRaw).finish()));
         assertIsDeliverTxSuccess(result);
       });
 
@@ -852,17 +852,17 @@ describe("SigningStargateClient", () => {
           gas: "200000",
         };
         const memo = "Use your power wisely";
-        const signed = await client.sign(faucet.address0, [msgAny], fee, memo);
+        const {txRaw} = await client.sign(faucet.address0, [msgAny], fee, memo);
 
-        const body = TxBody.decode(signed.bodyBytes);
-        const authInfo = AuthInfo.decode(signed.authInfoBytes);
+        const body = TxBody.decode(txRaw.bodyBytes);
+        const authInfo = AuthInfo.decode(txRaw.authInfoBytes);
         // From ModifyingSecp256k1HdWallet
         expect(body.memo).toEqual("This was modified");
         expect({ ...authInfo.fee!.amount[0] }).toEqual(coin(3000, "ucosm"));
         expect(authInfo.fee!.gasLimit.toNumber()).toEqual(333333);
 
         // ensure signature is valid
-        const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(signed).finish()));
+        const result = await client.broadcastTx(Uint8Array.from(TxRaw.encode(txRaw).finish()));
         assertIsDeliverTxSuccess(result);
       });
     });

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -1,4 +1,4 @@
-import { encodeSecp256k1Pubkey, makeSignDoc as makeSignDocAmino, StdFee } from "@cosmjs/amino";
+import {encodeSecp256k1Pubkey, makeSignDoc as makeSignDocAmino, StdFee, StdSignDoc} from "@cosmjs/amino";
 import { fromBase64 } from "@cosmjs/encoding";
 import { Int53, Uint53 } from "@cosmjs/math";
 import {
@@ -18,7 +18,7 @@ import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
 import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
 import { MsgDelegate, MsgUndelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
 import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
-import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import {SignDoc, TxRaw} from "cosmjs-types/cosmos/tx/v1beta1/tx";
 import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
 import { Height } from "cosmjs-types/ibc/core/client/v1/client";
 import Long from "long";
@@ -48,7 +48,7 @@ import {
   createIbcAminoConverters,
   createStakingAminoConverters,
 } from "./modules";
-import { DeliverTxResponse, StargateClient } from "./stargateclient";
+import {DeliverTxResponse, StargateClient, StargateClientOptions} from "./stargateclient";
 
 export const defaultRegistryTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/cosmos.base.v1beta1.Coin", Coin],
@@ -66,6 +66,14 @@ function createDefaultRegistry(): Registry {
 }
 
 /**
+ * Represents the various signing modes that can be supported by signers.
+ */
+export enum SigningMode {
+  AMINO,
+  DIRECT,
+}
+
+/**
  * Signing information for a single signer that is not included in the transaction.
  *
  * @see https://github.com/cosmos/cosmos-sdk/blob/v0.42.2/x/auth/signing/sign_mode_handler.go#L23-L37
@@ -74,6 +82,16 @@ export interface SignerData {
   readonly accountNumber: number;
   readonly sequence: number;
   readonly chainId: string;
+}
+
+/**
+ * Signature result returned by the signer.
+ * It contains also the SignerData and SignDoc that have been used to generate the signature.
+ */
+export interface SignatureResult {
+  readonly signerData: SignerData;
+  readonly signDoc: SignDoc | StdSignDoc;
+  readonly txRaw: TxRaw;
 }
 
 /** Use for testing only */
@@ -88,6 +106,7 @@ export interface SigningStargateClientOptions {
   readonly broadcastTimeoutMs?: number;
   readonly broadcastPollIntervalMs?: number;
   readonly gasPrice?: GasPrice;
+  readonly clientOptions?: StargateClientOptions;
 }
 
 function createDefaultTypes(prefix: string): AminoConverters {
@@ -107,9 +126,9 @@ export class SigningStargateClient extends StargateClient {
   public readonly broadcastTimeoutMs: number | undefined;
   public readonly broadcastPollIntervalMs: number | undefined;
 
-  private readonly signer: OfflineSigner;
-  private readonly aminoTypes: AminoTypes;
-  private readonly gasPrice: GasPrice | undefined;
+  protected readonly signer: OfflineSigner;
+  protected readonly aminoTypes: AminoTypes;
+  protected readonly gasPrice: GasPrice | undefined;
 
   public static async connectWithSigner(
     endpoint: string,
@@ -141,7 +160,7 @@ export class SigningStargateClient extends StargateClient {
     signer: OfflineSigner,
     options: SigningStargateClientOptions,
   ) {
-    super(tmClient);
+    super(tmClient, options.clientOptions || {});
     // TODO: do we really want to set a default here? Ideally we could get it from the signer such that users only have to set it once.
     const prefix = options.prefix ?? "cosmos";
     const { registry = createDefaultRegistry(), aminoTypes = new AminoTypes(createDefaultTypes(prefix)) } =
@@ -288,7 +307,7 @@ export class SigningStargateClient extends StargateClient {
     } else {
       usedFee = fee;
     }
-    const txRaw = await this.sign(signerAddress, messages, usedFee, memo);
+    const { txRaw } = await this.sign(signerAddress, messages, usedFee, memo);
     const txBytes = TxRaw.encode(txRaw).finish();
     return this.broadcastTx(txBytes, this.broadcastTimeoutMs, this.broadcastPollIntervalMs);
   }
@@ -309,7 +328,7 @@ export class SigningStargateClient extends StargateClient {
     fee: StdFee,
     memo: string,
     explicitSignerData?: SignerData,
-  ): Promise<TxRaw> {
+  ): Promise<SignatureResult> {
     let signerData: SignerData;
     if (explicitSignerData) {
       signerData = explicitSignerData;
@@ -323,18 +342,28 @@ export class SigningStargateClient extends StargateClient {
       };
     }
 
-    return isOfflineDirectSigner(this.signer)
+    return this.getSigningMode() == SigningMode.DIRECT
       ? this.signDirect(signerAddress, messages, fee, memo, signerData)
       : this.signAmino(signerAddress, messages, fee, memo, signerData);
   }
 
-  private async signAmino(
+  /**
+   * Returns the signing mode to be used.
+   * If you need another way to get the signing mode to be used (maybe calling a custom method
+   * of your signer), then you can simply override this.
+   * @protected
+   */
+  protected getSigningMode(): SigningMode {
+    return isOfflineDirectSigner(this.signer) ? SigningMode.DIRECT : SigningMode.AMINO;
+  }
+
+  protected async signAmino(
     signerAddress: string,
     messages: readonly EncodeObject[],
     fee: StdFee,
     memo: string,
     { accountNumber, sequence, chainId }: SignerData,
-  ): Promise<TxRaw> {
+  ): Promise<SignatureResult> {
     assert(!isOfflineDirectSigner(this.signer));
     const accountFromSigner = (await this.signer.getAccounts()).find(
       (account) => account.address === signerAddress,
@@ -364,20 +393,24 @@ export class SigningStargateClient extends StargateClient {
       signedGasLimit,
       signMode,
     );
-    return TxRaw.fromPartial({
-      bodyBytes: signedTxBodyBytes,
-      authInfoBytes: signedAuthInfoBytes,
-      signatures: [fromBase64(signature.signature)],
-    });
+    return {
+      signerData: {accountNumber, sequence, chainId},
+      signDoc,
+      txRaw: TxRaw.fromPartial({
+        bodyBytes: signedTxBodyBytes,
+        authInfoBytes: signedAuthInfoBytes,
+        signatures: [fromBase64(signature.signature)],
+      })
+    };
   }
 
-  private async signDirect(
+  protected async signDirect(
     signerAddress: string,
     messages: readonly EncodeObject[],
     fee: StdFee,
     memo: string,
     { accountNumber, sequence, chainId }: SignerData,
-  ): Promise<TxRaw> {
+  ): Promise<SignatureResult> {
     assert(isOfflineDirectSigner(this.signer));
     const accountFromSigner = (await this.signer.getAccounts()).find(
       (account) => account.address === signerAddress,
@@ -398,10 +431,14 @@ export class SigningStargateClient extends StargateClient {
     const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], fee.amount, gasLimit);
     const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
     const { signature, signed } = await this.signer.signDirect(signerAddress, signDoc);
-    return TxRaw.fromPartial({
-      bodyBytes: signed.bodyBytes,
-      authInfoBytes: signed.authInfoBytes,
-      signatures: [fromBase64(signature.signature)],
-    });
+    return {
+      signerData: {accountNumber, sequence, chainId},
+      signDoc,
+      txRaw: TxRaw.fromPartial({
+        bodyBytes: signed.bodyBytes,
+        authInfoBytes: signed.authInfoBytes,
+        signatures: [fromBase64(signature.signature)],
+      })
+    };
   }
 }

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -1,4 +1,4 @@
-import {encodeSecp256k1Pubkey, makeSignDoc as makeSignDocAmino, StdFee, StdSignDoc} from "@cosmjs/amino";
+import { encodeSecp256k1Pubkey, makeSignDoc as makeSignDocAmino, StdFee, StdSignDoc } from "@cosmjs/amino";
 import { fromBase64 } from "@cosmjs/encoding";
 import { Int53, Uint53 } from "@cosmjs/math";
 import {
@@ -18,7 +18,7 @@ import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
 import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
 import { MsgDelegate, MsgUndelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
 import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
-import {SignDoc, TxRaw} from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { SignDoc, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
 import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
 import { Height } from "cosmjs-types/ibc/core/client/v1/client";
 import Long from "long";
@@ -48,7 +48,7 @@ import {
   createIbcAminoConverters,
   createStakingAminoConverters,
 } from "./modules";
-import {DeliverTxResponse, StargateClient, StargateClientOptions} from "./stargateclient";
+import { DeliverTxResponse, StargateClient, StargateClientOptions } from "./stargateclient";
 
 export const defaultRegistryTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/cosmos.base.v1beta1.Coin", Coin],
@@ -69,8 +69,8 @@ function createDefaultRegistry(): Registry {
  * Represents the various signing modes that can be supported by signers.
  */
 export enum SigningMode {
-  AMINO,
-  DIRECT,
+  Amino,
+  Direct,
 }
 
 /**
@@ -342,7 +342,7 @@ export class SigningStargateClient extends StargateClient {
       };
     }
 
-    return this.getSigningMode() == SigningMode.DIRECT
+    return this.getSigningMode() == SigningMode.Direct
       ? this.signDirect(signerAddress, messages, fee, memo, signerData)
       : this.signAmino(signerAddress, messages, fee, memo, signerData);
   }
@@ -354,7 +354,7 @@ export class SigningStargateClient extends StargateClient {
    * @protected
    */
   protected getSigningMode(): SigningMode {
-    return isOfflineDirectSigner(this.signer) ? SigningMode.DIRECT : SigningMode.AMINO;
+    return isOfflineDirectSigner(this.signer) ? SigningMode.Direct : SigningMode.Amino;
   }
 
   protected async signAmino(
@@ -394,13 +394,13 @@ export class SigningStargateClient extends StargateClient {
       signMode,
     );
     return {
-      signerData: {accountNumber, sequence, chainId},
+      signerData: { accountNumber, sequence, chainId },
       signDoc,
       txRaw: TxRaw.fromPartial({
         bodyBytes: signedTxBodyBytes,
         authInfoBytes: signedAuthInfoBytes,
         signatures: [fromBase64(signature.signature)],
-      })
+      }),
     };
   }
 
@@ -432,13 +432,13 @@ export class SigningStargateClient extends StargateClient {
     const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
     const { signature, signed } = await this.signer.signDirect(signerAddress, signDoc);
     return {
-      signerData: {accountNumber, sequence, chainId},
+      signerData: { accountNumber, sequence, chainId },
       signDoc,
       txRaw: TxRaw.fromPartial({
         bodyBytes: signed.bodyBytes,
         authInfoBytes: signed.authInfoBytes,
         signatures: [fromBase64(signature.signature)],
-      })
+      }),
     };
   }
 }

--- a/packages/stargate/src/stargateclient.ts
+++ b/packages/stargate/src/stargateclient.ts
@@ -6,7 +6,7 @@ import { sleep } from "@cosmjs/utils";
 import { MsgData } from "cosmjs-types/cosmos/base/abci/v1beta1/abci";
 import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
 
-import {Account, accountFromAny, AccountParser} from "./accounts";
+import { Account, accountFromAny, AccountParser } from "./accounts";
 import {
   AuthExtension,
   BankExtension,
@@ -25,7 +25,6 @@ import {
   SearchTxFilter,
   SearchTxQuery,
 } from "./search";
-import {Any} from "cosmjs-types/google/protobuf/any";
 
 export class TimeoutError extends Error {
   public readonly txId: string;
@@ -138,7 +137,7 @@ export interface PrivateStargateClient {
 }
 
 export interface StargateClientOptions {
-  readonly accountParser?: AccountParser
+  readonly accountParser?: AccountParser;
 }
 
 export class StargateClient {
@@ -149,7 +148,10 @@ export class StargateClient {
   private chainId: string | undefined;
   private readonly accountParser: AccountParser | undefined;
 
-  public static async connect(endpoint: string, options: StargateClientOptions = {}): Promise<StargateClient> {
+  public static async connect(
+    endpoint: string,
+    options: StargateClientOptions = {},
+  ): Promise<StargateClient> {
     const tmClient = await Tendermint34Client.connect(endpoint);
     return new StargateClient(tmClient, options);
   }


### PR DESCRIPTION
This PR improves the overall code of `StargateClient` and `SigningStargateClient`. The main changes are the following: 
- introduced a new `StargateClientOptions` interface that allows setting custom options for `StargateClient`.  
   The most important option is the `accountParser` option, which must be an `AccountParser` instance and allows to provide the `StargateClient` a custom way of decoding Cosmos accounts. This is particularly useful to solve problems when reading account from chains that support custom account types (eg. the Desmos chain). This can solve problems like the one REStake is having: https://github.com/eco-stake/restake/issues/334
- changed the return type of the `signDirect`, `signAmino` and `sign` methods to be `SignatureResult` instead of `TxRaw`.  
   This allows clients to also get the data that has been used when generating the signature. This is particularly useful in cases where the resulting signature must later be verified offline (eg. in a signature-based authentication process). Without the data (account number, sequence and sign doc) used, the client would have to re-generate the signed bytes by hand. With this change, instead, the sign bytes are returned by the `sign` method directly without any other operations needed. 
- made the `signer`, `aminoTypes` and `registry` fields `protected` instead of `private`.  
   This allows classes extending the `SigningStargateClient` to easily access those fields if needed (eg. when performing operations that need to encode a message or else)
- added the `SigningMode` interface and the `getSigningMode` method to `StargateSigningClient`.  
   These allow classes extending `SigningStargateClient` to easily implement new ways of defining what signing algorithm should be used. For example, developers might want to define a custom way of choosing which signing algorithm to be used that is based on what a signer supports. We could have a signer that uses WalletConnect with multiple versions on the market: a way to determine if the direct method is supported might be to ask directly the signer rather than performing type checks    