### PR TITLE
Broadcasting transaction error is fixed with using a Promise object

### DIFF
--- a/packages/stargate/src/stargateclient.ts
+++ b/packages/stargate/src/stargateclient.ts
@@ -372,8 +372,10 @@ export class StargateClient {
 
     const broadcasted = await this.forceGetTmClient().broadcastTxSync({ tx });
     if (broadcasted.code) {
-      throw new Error(
-        `Broadcasting transaction failed with code ${broadcasted.code} (codespace: ${broadcasted.codeSpace}). Log: ${broadcasted.log}`,
+      return Promise.reject(
+        new Error(
+          `Broadcasting transaction failed with code ${broadcasted.code} (codespace: ${broadcasted.codeSpace}). Log: ${broadcasted.log}`,
+        ),
       );
     }
     const transactionId = toHex(broadcasted.hash).toUpperCase();


### PR DESCRIPTION
Broadcasting transaction failed error could not catch when `await` is not used. Promise object is returned to fix it. 

One can reproduce the same error by trying to send `0.00000002` `uatom` which will result in that error:

`Error is: Error: Broadcasting transaction failed with code 2 (codespace: sdk). Log: math/big: cannot unmarshal "0.02" into a *big.Int: tx parse error`

So, if `await` is not used, that error cannot be caught.