### PR TITLE
feat: allow to specify an AccountParser inside StargateClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- @cosmjs/stargate: Added the ability to specify a custom account parser for `StargateClient`
+
 ### Fixed
 
 - @cosmjs/proto-signing: Add missing runtime dependencies @cosmjs/encoding and

--- a/packages/stargate/src/accounts.ts
+++ b/packages/stargate/src/accounts.ts
@@ -36,8 +36,13 @@ function accountFromBaseAccount(input: BaseAccount): Account {
 }
 
 /**
- * Takes an `Any` encoded account from the chain and extracts some common
- * `Account` information from it. This is supposed to support the most relevant
+ * Represents a generic function that takes an `Any` encoded account from the chain
+ * and extracts some common `Account` information from it.
+ */
+export type AccountParser = (any: Any) => Account;
+
+/**
+ * Basic implementation of AccountParser. This is supposed to support the most relevant
  * common Cosmos SDK account types. If you need support for exotic account types,
  * you'll need to write your own account decoder.
  */

--- a/packages/stargate/src/index.ts
+++ b/packages/stargate/src/index.ts
@@ -1,4 +1,4 @@
-export { Account, accountFromAny } from "./accounts";
+export { Account, accountFromAny, AccountParser } from "./accounts";
 export { AminoConverter, AminoConverters, AminoTypes } from "./aminotypes";
 export { calculateFee, GasPrice } from "./fee";
 export * as logs from "./logs";
@@ -117,6 +117,7 @@ export {
   isDeliverTxSuccess,
   SequenceResponse,
   StargateClient,
+  StargateClientOptions,
   TimeoutError,
 } from "./stargateclient";
 export { StdFee } from "@cosmjs/amino";

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -81,14 +81,13 @@ export interface PrivateSigningStargateClient {
   readonly registry: Registry;
 }
 
-export interface SigningStargateClientOptions {
+export interface SigningStargateClientOptions extends StargateClientOptions {
   readonly registry?: Registry;
   readonly aminoTypes?: AminoTypes;
   readonly prefix?: string;
   readonly broadcastTimeoutMs?: number;
   readonly broadcastPollIntervalMs?: number;
   readonly gasPrice?: GasPrice;
-  readonly clientOptions?: StargateClientOptions;
 }
 
 function createDefaultTypes(prefix: string): AminoConverters {
@@ -142,7 +141,7 @@ export class SigningStargateClient extends StargateClient {
     signer: OfflineSigner,
     options: SigningStargateClientOptions,
   ) {
-    super(tmClient, options.clientOptions || {});
+    super(tmClient, options);
     // TODO: do we really want to set a default here? Ideally we could get it from the signer such that users only have to set it once.
     const prefix = options.prefix ?? "cosmos";
     const { registry = createDefaultRegistry(), aminoTypes = new AminoTypes(createDefaultTypes(prefix)) } =

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -48,7 +48,7 @@ import {
   createIbcAminoConverters,
   createStakingAminoConverters,
 } from "./modules";
-import { DeliverTxResponse, StargateClient } from "./stargateclient";
+import { DeliverTxResponse, StargateClient, StargateClientOptions } from "./stargateclient";
 
 export const defaultRegistryTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/cosmos.base.v1beta1.Coin", Coin],
@@ -88,6 +88,7 @@ export interface SigningStargateClientOptions {
   readonly broadcastTimeoutMs?: number;
   readonly broadcastPollIntervalMs?: number;
   readonly gasPrice?: GasPrice;
+  readonly clientOptions?: StargateClientOptions;
 }
 
 function createDefaultTypes(prefix: string): AminoConverters {
@@ -141,7 +142,7 @@ export class SigningStargateClient extends StargateClient {
     signer: OfflineSigner,
     options: SigningStargateClientOptions,
   ) {
-    super(tmClient);
+    super(tmClient, options.clientOptions || {});
     // TODO: do we really want to set a default here? Ideally we could get it from the signer such that users only have to set it once.
     const prefix = options.prefix ?? "cosmos";
     const { registry = createDefaultRegistry(), aminoTypes = new AminoTypes(createDefaultTypes(prefix)) } =

--- a/packages/stargate/src/stargateclient.ts
+++ b/packages/stargate/src/stargateclient.ts
@@ -6,7 +6,7 @@ import { sleep } from "@cosmjs/utils";
 import { MsgData } from "cosmjs-types/cosmos/base/abci/v1beta1/abci";
 import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
 
-import { Account, accountFromAny } from "./accounts";
+import { Account, accountFromAny, AccountParser } from "./accounts";
 import {
   AuthExtension,
   BankExtension,
@@ -136,19 +136,27 @@ export interface PrivateStargateClient {
   readonly tmClient: Tendermint34Client | undefined;
 }
 
+export interface StargateClientOptions {
+  readonly accountParser?: AccountParser;
+}
+
 export class StargateClient {
   private readonly tmClient: Tendermint34Client | undefined;
   private readonly queryClient:
     | (QueryClient & AuthExtension & BankExtension & StakingExtension & TxExtension)
     | undefined;
   private chainId: string | undefined;
+  private readonly accountParser: AccountParser | undefined;
 
-  public static async connect(endpoint: string): Promise<StargateClient> {
+  public static async connect(
+    endpoint: string,
+    options: StargateClientOptions = {},
+  ): Promise<StargateClient> {
     const tmClient = await Tendermint34Client.connect(endpoint);
-    return new StargateClient(tmClient);
+    return new StargateClient(tmClient, options);
   }
 
-  protected constructor(tmClient: Tendermint34Client | undefined) {
+  protected constructor(tmClient: Tendermint34Client | undefined, options: StargateClientOptions) {
     if (tmClient) {
       this.tmClient = tmClient;
       this.queryClient = QueryClient.withExtensions(
@@ -158,6 +166,8 @@ export class StargateClient {
         setupStakingExtension,
         setupTxExtension,
       );
+      const { accountParser = accountFromAny } = options;
+      this.accountParser = accountParser;
     }
   }
 
@@ -191,6 +201,17 @@ export class StargateClient {
     return this.queryClient;
   }
 
+  protected getAccountParser(): AccountParser | undefined {
+    return this.accountParser;
+  }
+
+  protected forceGetAccountParser(): AccountParser {
+    if (!this.accountParser) {
+      throw new Error("Account parser not available. You cannot use online functionality in offline mode.");
+    }
+    return this.accountParser;
+  }
+
   public async getChainId(): Promise<string> {
     if (!this.chainId) {
       const response = await this.forceGetTmClient().status();
@@ -210,7 +231,7 @@ export class StargateClient {
   public async getAccount(searchAddress: string): Promise<Account | null> {
     try {
       const account = await this.forceGetQueryClient().auth.account(searchAddress);
-      return account ? accountFromAny(account) : null;
+      return account ? this.forceGetAccountParser()(account) : null;
     } catch (error: any) {
       if (/rpc error: code = NotFound/i.test(error.toString())) {
         return null;


### PR DESCRIPTION
This PR introduces a new `StargateClientOptions` interface that allows setting custom options for `StargateClient`.  

The most important option is the `accountParser` option, which must be an `AccountParser` instance and allows to provide the `StargateClient` a custom way of decoding Cosmos accounts. This is particularly useful to solve problems when reading account from chains that support custom account types (eg. the Desmos chain). This can solve problems like the one REStake is having: https://github.com/eco-stake/restake/issues/334