### PR TITLE
Feat: option to add fee payer account

### DIFF
--- a/packages/amino/src/signdoc.ts
+++ b/packages/amino/src/signdoc.ts
@@ -13,6 +13,7 @@ export interface StdFee {
   readonly amount: readonly Coin[];
   readonly gas: string;
   readonly granter?: string;
+  readonly payer?: string;
 }
 
 /**

--- a/packages/amino/src/signdoc.ts
+++ b/packages/amino/src/signdoc.ts
@@ -12,6 +12,7 @@ export interface AminoMsg {
 export interface StdFee {
   readonly amount: readonly Coin[];
   readonly gas: string;
+  readonly granter?: string;
 }
 
 /**

--- a/packages/cosmwasm-stargate/src/cosmwasmclient.searchtx.spec.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.searchtx.spec.ts
@@ -79,7 +79,8 @@ async function sendTokens(
     },
   ];
   const gasLimit = 200000;
-  const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit);
+  const feePayer = "";
+  const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit, feePayer);
 
   const chainId = await client.getChainId();
   const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);

--- a/packages/cosmwasm-stargate/src/cosmwasmclient.searchtx.spec.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.searchtx.spec.ts
@@ -79,8 +79,8 @@ async function sendTokens(
     },
   ];
   const gasLimit = 200000;
-  const feeGranter = "";
-  const feePayer = "";
+  const feeGranter = undefined;
+  const feePayer = undefined;
   const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit, feeGranter, feePayer);
 
   const chainId = await client.getChainId();

--- a/packages/cosmwasm-stargate/src/cosmwasmclient.searchtx.spec.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.searchtx.spec.ts
@@ -79,8 +79,9 @@ async function sendTokens(
     },
   ];
   const gasLimit = 200000;
+  const feeGranter = "";
   const feePayer = "";
-  const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit, feePayer);
+  const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit, feeGranter, feePayer);
 
   const chainId = await client.getChainId();
   const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);

--- a/packages/cosmwasm-stargate/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.spec.ts
@@ -203,8 +203,15 @@ describe("CosmWasmClient", () => {
       };
       const txBodyBytes = registry.encode(txBody);
       const gasLimit = Int53.fromString(fee.gas).toNumber();
+      const feeGranter = "";
       const feePayer = "";
-      const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], fee.amount, gasLimit, feePayer);
+      const authInfoBytes = makeAuthInfoBytes(
+        [{ pubkey, sequence }],
+        fee.amount,
+        gasLimit,
+        feeGranter,
+        feePayer,
+      );
       const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
       const { signed, signature } = await wallet.signDirect(alice.address0, signDoc);
       const txRaw = TxRaw.fromPartial({

--- a/packages/cosmwasm-stargate/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.spec.ts
@@ -203,7 +203,7 @@ describe("CosmWasmClient", () => {
       };
       const txBodyBytes = registry.encode(txBody);
       const gasLimit = Int53.fromString(fee.gas).toNumber();
-      const feePayer = ""
+      const feePayer = "";
       const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], fee.amount, gasLimit, feePayer);
       const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
       const { signed, signature } = await wallet.signDirect(alice.address0, signDoc);

--- a/packages/cosmwasm-stargate/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.spec.ts
@@ -203,8 +203,8 @@ describe("CosmWasmClient", () => {
       };
       const txBodyBytes = registry.encode(txBody);
       const gasLimit = Int53.fromString(fee.gas).toNumber();
-      const feeGranter = "";
-      const feePayer = "";
+      const feeGranter = undefined;
+      const feePayer = undefined;
       const authInfoBytes = makeAuthInfoBytes(
         [{ pubkey, sequence }],
         fee.amount,

--- a/packages/cosmwasm-stargate/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.spec.ts
@@ -203,7 +203,8 @@ describe("CosmWasmClient", () => {
       };
       const txBodyBytes = registry.encode(txBody);
       const gasLimit = Int53.fromString(fee.gas).toNumber();
-      const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], fee.amount, gasLimit);
+      const feePayer = ""
+      const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], fee.amount, gasLimit, feePayer);
       const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
       const { signed, signature } = await wallet.signDirect(alice.address0, signDoc);
       const txRaw = TxRaw.fromPartial({

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -559,7 +559,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     const signedTxBodyBytes = this.registry.encode(signedTxBody);
     const signedGasLimit = Int53.fromString(signed.fee.gas).toNumber();
     const signedSequence = Int53.fromString(signed.sequence).toNumber();
-    const signedFeePayer = ""
+    const signedFeePayer = "";
     const signedAuthInfoBytes = makeAuthInfoBytes(
       [{ pubkey, sequence: signedSequence }],
       signed.fee.amount,
@@ -598,7 +598,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     };
     const txBodyBytes = this.registry.encode(txBody);
     const gasLimit = Int53.fromString(fee.gas).toNumber();
-    const feePayer = fee.granter == undefined ? "" : fee.granter
+    const feePayer = fee.granter == undefined ? "" : fee.granter;
     const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], fee.amount, gasLimit, feePayer);
     const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
     const { signature, signed } = await this.signer.signDirect(signerAddress, signDoc);

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -559,11 +559,13 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     const signedTxBodyBytes = this.registry.encode(signedTxBody);
     const signedGasLimit = Int53.fromString(signed.fee.gas).toNumber();
     const signedSequence = Int53.fromString(signed.sequence).toNumber();
-    const signedFeePayer = "";
+    const signedFeeGranter = signed.fee.granter == undefined ? "" : signed.fee.granter;
+    const signedFeePayer = signed.fee.payer == undefined ? "" : signed.fee.payer;
     const signedAuthInfoBytes = makeAuthInfoBytes(
       [{ pubkey, sequence: signedSequence }],
       signed.fee.amount,
       signedGasLimit,
+      signedFeeGranter,
       signedFeePayer,
       signMode,
     );
@@ -598,8 +600,15 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     };
     const txBodyBytes = this.registry.encode(txBody);
     const gasLimit = Int53.fromString(fee.gas).toNumber();
-    const feePayer = fee.granter == undefined ? "" : fee.granter;
-    const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], fee.amount, gasLimit, feePayer);
+    const feePayer = fee.payer == undefined ? "" : fee.payer;
+    const feeGranter = fee.granter == undefined ? "" : fee.granter;
+    const authInfoBytes = makeAuthInfoBytes(
+      [{ pubkey, sequence }],
+      fee.amount,
+      gasLimit,
+      feeGranter,
+      feePayer,
+    );
     const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
     const { signature, signed } = await this.signer.signDirect(signerAddress, signDoc);
     return TxRaw.fromPartial({

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -559,10 +559,12 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     const signedTxBodyBytes = this.registry.encode(signedTxBody);
     const signedGasLimit = Int53.fromString(signed.fee.gas).toNumber();
     const signedSequence = Int53.fromString(signed.sequence).toNumber();
+    const signedFeePayer = ""
     const signedAuthInfoBytes = makeAuthInfoBytes(
       [{ pubkey, sequence: signedSequence }],
       signed.fee.amount,
       signedGasLimit,
+      signedFeePayer,
       signMode,
     );
     return TxRaw.fromPartial({
@@ -596,7 +598,8 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     };
     const txBodyBytes = this.registry.encode(txBody);
     const gasLimit = Int53.fromString(fee.gas).toNumber();
-    const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], fee.amount, gasLimit);
+    const feePayer = fee.granter == undefined ? "" : fee.granter
+    const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], fee.amount, gasLimit, feePayer);
     const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
     const { signature, signed } = await this.signer.signDirect(signerAddress, signDoc);
     return TxRaw.fromPartial({

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -559,14 +559,12 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     const signedTxBodyBytes = this.registry.encode(signedTxBody);
     const signedGasLimit = Int53.fromString(signed.fee.gas).toNumber();
     const signedSequence = Int53.fromString(signed.sequence).toNumber();
-    const signedFeeGranter = signed.fee.granter == undefined ? "" : signed.fee.granter;
-    const signedFeePayer = signed.fee.payer == undefined ? "" : signed.fee.payer;
     const signedAuthInfoBytes = makeAuthInfoBytes(
       [{ pubkey, sequence: signedSequence }],
       signed.fee.amount,
       signedGasLimit,
-      signedFeeGranter,
-      signedFeePayer,
+      signed.fee.granter,
+      signed.fee.payer,
       signMode,
     );
     return TxRaw.fromPartial({
@@ -600,14 +598,12 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     };
     const txBodyBytes = this.registry.encode(txBody);
     const gasLimit = Int53.fromString(fee.gas).toNumber();
-    const feePayer = fee.payer == undefined ? "" : fee.payer;
-    const feeGranter = fee.granter == undefined ? "" : fee.granter;
     const authInfoBytes = makeAuthInfoBytes(
       [{ pubkey, sequence }],
       fee.amount,
       gasLimit,
-      feeGranter,
-      feePayer,
+      fee.granter,
+      fee.payer,
     );
     const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
     const { signature, signed } = await this.signer.signDirect(signerAddress, signDoc);

--- a/packages/cosmwasm-stargate/src/testutils.spec.ts
+++ b/packages/cosmwasm-stargate/src/testutils.spec.ts
@@ -224,8 +224,8 @@ export class ModifyingDirectSecp256k1HdWallet extends DirectSecp256k1HdWallet {
     }));
     const modifiedFeeAmount = coins(3000, "ucosm");
     const modifiedGasLimit = 333333;
-    const modifiedFeeGranter = "";
-    const modifiedFeePayer = "";
+    const modifiedFeeGranter = undefined;
+    const modifiedFeePayer = undefined;
     const modifiedSignDoc = {
       ...signDoc,
       bodyBytes: Uint8Array.from(TxBody.encode(modifiedTxBody).finish()),

--- a/packages/cosmwasm-stargate/src/testutils.spec.ts
+++ b/packages/cosmwasm-stargate/src/testutils.spec.ts
@@ -224,6 +224,7 @@ export class ModifyingDirectSecp256k1HdWallet extends DirectSecp256k1HdWallet {
     }));
     const modifiedFeeAmount = coins(3000, "ucosm");
     const modifiedGasLimit = 333333;
+    const modifiedFeePayer = "";
     const modifiedSignDoc = {
       ...signDoc,
       bodyBytes: Uint8Array.from(TxBody.encode(modifiedTxBody).finish()),
@@ -231,6 +232,7 @@ export class ModifyingDirectSecp256k1HdWallet extends DirectSecp256k1HdWallet {
         signers,
         modifiedFeeAmount,
         modifiedGasLimit,
+        modifiedFeePayer,
         SignMode.SIGN_MODE_DIRECT,
       ),
     };

--- a/packages/cosmwasm-stargate/src/testutils.spec.ts
+++ b/packages/cosmwasm-stargate/src/testutils.spec.ts
@@ -224,6 +224,7 @@ export class ModifyingDirectSecp256k1HdWallet extends DirectSecp256k1HdWallet {
     }));
     const modifiedFeeAmount = coins(3000, "ucosm");
     const modifiedGasLimit = 333333;
+    const modifiedFeeGranter = "";
     const modifiedFeePayer = "";
     const modifiedSignDoc = {
       ...signDoc,
@@ -232,6 +233,7 @@ export class ModifyingDirectSecp256k1HdWallet extends DirectSecp256k1HdWallet {
         signers,
         modifiedFeeAmount,
         modifiedGasLimit,
+        modifiedFeeGranter,
         modifiedFeePayer,
         SignMode.SIGN_MODE_DIRECT,
       ),

--- a/packages/proto-signing/src/directsecp256k1hdwallet.spec.ts
+++ b/packages/proto-signing/src/directsecp256k1hdwallet.spec.ts
@@ -261,10 +261,11 @@ describe("DirectSecp256k1HdWallet", () => {
       };
       const fee = coins(2000, "ucosm");
       const gasLimit = 200000;
+      const feePayer = ""
       const chainId = "simd-testing";
       const signDoc = makeSignDoc(
         fromHex(bodyBytes),
-        makeAuthInfoBytes([{ pubkey, sequence }], fee, gasLimit),
+        makeAuthInfoBytes([{ pubkey, sequence }], fee, gasLimit, feePayer),
         chainId,
         accountNumber,
       );

--- a/packages/proto-signing/src/directsecp256k1hdwallet.spec.ts
+++ b/packages/proto-signing/src/directsecp256k1hdwallet.spec.ts
@@ -261,11 +261,12 @@ describe("DirectSecp256k1HdWallet", () => {
       };
       const fee = coins(2000, "ucosm");
       const gasLimit = 200000;
+      const feeGranter = "";
       const feePayer = "";
       const chainId = "simd-testing";
       const signDoc = makeSignDoc(
         fromHex(bodyBytes),
-        makeAuthInfoBytes([{ pubkey, sequence }], fee, gasLimit, feePayer),
+        makeAuthInfoBytes([{ pubkey, sequence }], fee, gasLimit, feeGranter, feePayer),
         chainId,
         accountNumber,
       );

--- a/packages/proto-signing/src/directsecp256k1hdwallet.spec.ts
+++ b/packages/proto-signing/src/directsecp256k1hdwallet.spec.ts
@@ -261,7 +261,7 @@ describe("DirectSecp256k1HdWallet", () => {
       };
       const fee = coins(2000, "ucosm");
       const gasLimit = 200000;
-      const feePayer = ""
+      const feePayer = "";
       const chainId = "simd-testing";
       const signDoc = makeSignDoc(
         fromHex(bodyBytes),

--- a/packages/proto-signing/src/directsecp256k1wallet.spec.ts
+++ b/packages/proto-signing/src/directsecp256k1wallet.spec.ts
@@ -44,9 +44,10 @@ describe("DirectSecp256k1Wallet", () => {
       const fee = coins(2000, "ucosm");
       const gasLimit = 200000;
       const chainId = "simd-testing";
+      const feePayer = "";
       const signDoc = makeSignDoc(
         fromHex(bodyBytes),
-        makeAuthInfoBytes([{ pubkey, sequence }], fee, gasLimit),
+        makeAuthInfoBytes([{ pubkey, sequence }], fee, gasLimit, feePayer),
         chainId,
         accountNumber,
       );

--- a/packages/proto-signing/src/directsecp256k1wallet.spec.ts
+++ b/packages/proto-signing/src/directsecp256k1wallet.spec.ts
@@ -45,9 +45,10 @@ describe("DirectSecp256k1Wallet", () => {
       const gasLimit = 200000;
       const chainId = "simd-testing";
       const feePayer = "";
+      const feeGranter = "";
       const signDoc = makeSignDoc(
         fromHex(bodyBytes),
-        makeAuthInfoBytes([{ pubkey, sequence }], fee, gasLimit, feePayer),
+        makeAuthInfoBytes([{ pubkey, sequence }], fee, gasLimit, feeGranter, feePayer),
         chainId,
         accountNumber,
       );

--- a/packages/proto-signing/src/signing.ts
+++ b/packages/proto-signing/src/signing.ts
@@ -42,8 +42,8 @@ export function makeAuthInfoBytes(
     fee: {
       amount: [...feeAmount],
       gasLimit: Long.fromNumber(gasLimit),
-      granter: feePayer
-    }
+      granter: feePayer,
+    },
   };
   return AuthInfo.encode(AuthInfo.fromPartial(authInfo)).finish();
 }

--- a/packages/proto-signing/src/signing.ts
+++ b/packages/proto-signing/src/signing.ts
@@ -34,6 +34,7 @@ export function makeAuthInfoBytes(
   signers: ReadonlyArray<{ readonly pubkey: Any; readonly sequence: number }>,
   feeAmount: readonly Coin[],
   gasLimit: number,
+  feePayer: string,
   signMode = SignMode.SIGN_MODE_DIRECT,
 ): Uint8Array {
   const authInfo = {
@@ -41,7 +42,8 @@ export function makeAuthInfoBytes(
     fee: {
       amount: [...feeAmount],
       gasLimit: Long.fromNumber(gasLimit),
-    },
+      granter: feePayer
+    }
   };
   return AuthInfo.encode(AuthInfo.fromPartial(authInfo)).finish();
 }

--- a/packages/proto-signing/src/signing.ts
+++ b/packages/proto-signing/src/signing.ts
@@ -34,6 +34,7 @@ export function makeAuthInfoBytes(
   signers: ReadonlyArray<{ readonly pubkey: Any; readonly sequence: number }>,
   feeAmount: readonly Coin[],
   gasLimit: number,
+  feeGranter: string | undefined,
   feePayer: string | undefined,
   signMode = SignMode.SIGN_MODE_DIRECT,
 ): Uint8Array {
@@ -42,7 +43,8 @@ export function makeAuthInfoBytes(
     fee: {
       amount: [...feeAmount],
       gasLimit: Long.fromNumber(gasLimit),
-      granter: feePayer,
+      granter: feeGranter,
+      payer: feePayer,
     },
   };
   return AuthInfo.encode(AuthInfo.fromPartial(authInfo)).finish();

--- a/packages/proto-signing/src/signing.ts
+++ b/packages/proto-signing/src/signing.ts
@@ -34,7 +34,7 @@ export function makeAuthInfoBytes(
   signers: ReadonlyArray<{ readonly pubkey: Any; readonly sequence: number }>,
   feeAmount: readonly Coin[],
   gasLimit: number,
-  feePayer: string,
+  feePayer: string | undefined,
   signMode = SignMode.SIGN_MODE_DIRECT,
 ): Uint8Array {
   const authInfo = {

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -362,11 +362,13 @@ export class SigningStargateClient extends StargateClient {
     const signedTxBodyBytes = this.registry.encode(signedTxBodyEncodeObject);
     const signedGasLimit = Int53.fromString(signed.fee.gas).toNumber();
     const signedSequence = Int53.fromString(signed.sequence).toNumber();
-    const signedFeePayer = signed.fee.granter == undefined ? "" : signed.fee.granter;
+    const signedFeeGranter = signed.fee.granter == undefined ? "" : signed.fee.granter;
+    const signedFeePayer = signed.fee.payer == undefined ? "" : signed.fee.payer;
     const signedAuthInfoBytes = makeAuthInfoBytes(
       [{ pubkey, sequence: signedSequence }],
       signed.fee.amount,
       signedGasLimit,
+      signedFeeGranter,
       signedFeePayer,
       signMode,
     );
@@ -401,8 +403,15 @@ export class SigningStargateClient extends StargateClient {
     };
     const txBodyBytes = this.registry.encode(txBodyEncodeObject);
     const gasLimit = Int53.fromString(fee.gas).toNumber();
-    const feePayer = fee.granter == undefined ? "" : fee.granter;
-    const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], fee.amount, gasLimit, feePayer);
+    const feeGranter = fee.granter == undefined ? "" : fee.granter;
+    const feePayer = fee.payer == undefined ? "" : fee.payer;
+    const authInfoBytes = makeAuthInfoBytes(
+      [{ pubkey, sequence }],
+      fee.amount,
+      gasLimit,
+      feeGranter,
+      feePayer,
+    );
     const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
     const { signature, signed } = await this.signer.signDirect(signerAddress, signDoc);
     return TxRaw.fromPartial({

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -362,7 +362,7 @@ export class SigningStargateClient extends StargateClient {
     const signedTxBodyBytes = this.registry.encode(signedTxBodyEncodeObject);
     const signedGasLimit = Int53.fromString(signed.fee.gas).toNumber();
     const signedSequence = Int53.fromString(signed.sequence).toNumber();
-    const signedFeePayer = signed.fee.granter == undefined ? "" : signed.fee.granter 
+    const signedFeePayer = signed.fee.granter == undefined ? "" : signed.fee.granter;
     const signedAuthInfoBytes = makeAuthInfoBytes(
       [{ pubkey, sequence: signedSequence }],
       signed.fee.amount,
@@ -401,7 +401,7 @@ export class SigningStargateClient extends StargateClient {
     };
     const txBodyBytes = this.registry.encode(txBodyEncodeObject);
     const gasLimit = Int53.fromString(fee.gas).toNumber();
-    const feePayer = fee.granter == undefined ? "" : fee.granter
+    const feePayer = fee.granter == undefined ? "" : fee.granter;
     const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], fee.amount, gasLimit, feePayer);
     const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
     const { signature, signed } = await this.signer.signDirect(signerAddress, signDoc);

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -362,10 +362,12 @@ export class SigningStargateClient extends StargateClient {
     const signedTxBodyBytes = this.registry.encode(signedTxBodyEncodeObject);
     const signedGasLimit = Int53.fromString(signed.fee.gas).toNumber();
     const signedSequence = Int53.fromString(signed.sequence).toNumber();
+    const signedFeePayer = signed.fee.granter == undefined ? "" : signed.fee.granter 
     const signedAuthInfoBytes = makeAuthInfoBytes(
       [{ pubkey, sequence: signedSequence }],
       signed.fee.amount,
       signedGasLimit,
+      signedFeePayer,
       signMode,
     );
     return TxRaw.fromPartial({
@@ -399,7 +401,8 @@ export class SigningStargateClient extends StargateClient {
     };
     const txBodyBytes = this.registry.encode(txBodyEncodeObject);
     const gasLimit = Int53.fromString(fee.gas).toNumber();
-    const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], fee.amount, gasLimit);
+    const feePayer = fee.granter == undefined ? "" : fee.granter
+    const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], fee.amount, gasLimit, feePayer);
     const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
     const { signature, signed } = await this.signer.signDirect(signerAddress, signDoc);
     return TxRaw.fromPartial({

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -362,14 +362,12 @@ export class SigningStargateClient extends StargateClient {
     const signedTxBodyBytes = this.registry.encode(signedTxBodyEncodeObject);
     const signedGasLimit = Int53.fromString(signed.fee.gas).toNumber();
     const signedSequence = Int53.fromString(signed.sequence).toNumber();
-    const signedFeeGranter = signed.fee.granter == undefined ? "" : signed.fee.granter;
-    const signedFeePayer = signed.fee.payer == undefined ? "" : signed.fee.payer;
     const signedAuthInfoBytes = makeAuthInfoBytes(
       [{ pubkey, sequence: signedSequence }],
       signed.fee.amount,
       signedGasLimit,
-      signedFeeGranter,
-      signedFeePayer,
+      signed.fee.granter,
+      signed.fee.payer,
       signMode,
     );
     return TxRaw.fromPartial({
@@ -403,14 +401,12 @@ export class SigningStargateClient extends StargateClient {
     };
     const txBodyBytes = this.registry.encode(txBodyEncodeObject);
     const gasLimit = Int53.fromString(fee.gas).toNumber();
-    const feeGranter = fee.granter == undefined ? "" : fee.granter;
-    const feePayer = fee.payer == undefined ? "" : fee.payer;
     const authInfoBytes = makeAuthInfoBytes(
       [{ pubkey, sequence }],
       fee.amount,
       gasLimit,
-      feeGranter,
-      feePayer,
+      fee.granter,
+      fee.payer,
     );
     const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
     const { signature, signed } = await this.signer.signDirect(signerAddress, signDoc);

--- a/packages/stargate/src/stargateclient.searchtx.spec.ts
+++ b/packages/stargate/src/stargateclient.searchtx.spec.ts
@@ -74,7 +74,8 @@ async function sendTokens(
     },
   ];
   const gasLimit = 200000;
-  const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit);
+  const feePayer = "";
+  const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit, feePayer);
 
   const chainId = await client.getChainId();
   const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);

--- a/packages/stargate/src/stargateclient.searchtx.spec.ts
+++ b/packages/stargate/src/stargateclient.searchtx.spec.ts
@@ -74,8 +74,9 @@ async function sendTokens(
     },
   ];
   const gasLimit = 200000;
+  const feeGranter = "";
   const feePayer = "";
-  const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit, feePayer);
+  const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit, feeGranter, feePayer);
 
   const chainId = await client.getChainId();
   const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);

--- a/packages/stargate/src/stargateclient.searchtx.spec.ts
+++ b/packages/stargate/src/stargateclient.searchtx.spec.ts
@@ -74,8 +74,8 @@ async function sendTokens(
     },
   ];
   const gasLimit = 200000;
-  const feeGranter = "";
-  const feePayer = "";
+  const feeGranter = undefined;
+  const feePayer = undefined;
   const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit, feeGranter, feePayer);
 
   const chainId = await client.getChainId();

--- a/packages/stargate/src/stargateclient.spec.ts
+++ b/packages/stargate/src/stargateclient.spec.ts
@@ -360,7 +360,8 @@ describe("StargateClient", () => {
       const { accountNumber, sequence } = (await client.getSequence(address))!;
       const feeAmount = coins(2000, "ucosm");
       const gasLimit = 200000;
-      const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit);
+      const feePayer = "";
+      const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit, feePayer);
 
       const chainId = await client.getChainId();
       const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
@@ -417,7 +418,8 @@ describe("StargateClient", () => {
       const { accountNumber, sequence } = (await client.getSequence(address))!;
       const feeAmount = coins(2000, "ucosm");
       const gasLimit = 200000;
-      const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit, sequence);
+      const feePayer = "";
+      const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit, feePayer, sequence);
 
       const chainId = await client.getChainId();
       const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
@@ -468,9 +470,10 @@ describe("StargateClient", () => {
       const chainId = await client.getChainId();
       const feeAmount = coins(2000, "ucosm");
       const gasLimit = 200000;
+      const feePayer = "";
 
       const { accountNumber: accountNumber1, sequence: sequence1 } = (await client.getSequence(address))!;
-      const authInfoBytes1 = makeAuthInfoBytes([{ pubkey, sequence: sequence1 }], feeAmount, gasLimit);
+      const authInfoBytes1 = makeAuthInfoBytes([{ pubkey, sequence: sequence1 }], feeAmount, gasLimit, feePayer);
       const signDoc1 = makeSignDoc(txBodyBytes, authInfoBytes1, chainId, accountNumber1);
       const { signature: signature1 } = await wallet.signDirect(address, signDoc1);
       const txRaw1 = TxRaw.fromPartial({
@@ -484,7 +487,7 @@ describe("StargateClient", () => {
       assertIsDeliverTxSuccess(txResult);
 
       const { accountNumber: accountNumber2, sequence: sequence2 } = (await client.getSequence(address))!;
-      const authInfoBytes2 = makeAuthInfoBytes([{ pubkey, sequence: sequence2 }], feeAmount, gasLimit);
+      const authInfoBytes2 = makeAuthInfoBytes([{ pubkey, sequence: sequence2 }], feeAmount, gasLimit, feePayer);
       const signDoc2 = makeSignDoc(txBodyBytes, authInfoBytes2, chainId, accountNumber2);
       const { signature: signature2 } = await wallet.signDirect(address, signDoc2);
       const txRaw2 = TxRaw.fromPartial({

--- a/packages/stargate/src/stargateclient.spec.ts
+++ b/packages/stargate/src/stargateclient.spec.ts
@@ -360,8 +360,8 @@ describe("StargateClient", () => {
       const { accountNumber, sequence } = (await client.getSequence(address))!;
       const feeAmount = coins(2000, "ucosm");
       const gasLimit = 200000;
-      const feeGranter = "";
-      const feePayer = "";
+      const feeGranter = undefined;
+      const feePayer = undefined;
       const authInfoBytes = makeAuthInfoBytes(
         [{ pubkey, sequence }],
         feeAmount,
@@ -425,8 +425,8 @@ describe("StargateClient", () => {
       const { accountNumber, sequence } = (await client.getSequence(address))!;
       const feeAmount = coins(2000, "ucosm");
       const gasLimit = 200000;
-      const feeGranter = "";
-      const feePayer = "";
+      const feeGranter = undefined;
+      const feePayer = undefined;
       const authInfoBytes = makeAuthInfoBytes(
         [{ pubkey, sequence }],
         feeAmount,

--- a/packages/stargate/src/stargateclient.spec.ts
+++ b/packages/stargate/src/stargateclient.spec.ts
@@ -360,8 +360,15 @@ describe("StargateClient", () => {
       const { accountNumber, sequence } = (await client.getSequence(address))!;
       const feeAmount = coins(2000, "ucosm");
       const gasLimit = 200000;
+      const feeGranter = "";
       const feePayer = "";
-      const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit, feePayer);
+      const authInfoBytes = makeAuthInfoBytes(
+        [{ pubkey, sequence }],
+        feeAmount,
+        gasLimit,
+        feeGranter,
+        feePayer,
+      );
 
       const chainId = await client.getChainId();
       const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
@@ -418,11 +425,13 @@ describe("StargateClient", () => {
       const { accountNumber, sequence } = (await client.getSequence(address))!;
       const feeAmount = coins(2000, "ucosm");
       const gasLimit = 200000;
+      const feeGranter = "";
       const feePayer = "";
       const authInfoBytes = makeAuthInfoBytes(
         [{ pubkey, sequence }],
         feeAmount,
         gasLimit,
+        feeGranter,
         feePayer,
         sequence,
       );
@@ -476,6 +485,7 @@ describe("StargateClient", () => {
       const chainId = await client.getChainId();
       const feeAmount = coins(2000, "ucosm");
       const gasLimit = 200000;
+      const feeGranter = "";
       const feePayer = "";
 
       const { accountNumber: accountNumber1, sequence: sequence1 } = (await client.getSequence(address))!;
@@ -483,6 +493,7 @@ describe("StargateClient", () => {
         [{ pubkey, sequence: sequence1 }],
         feeAmount,
         gasLimit,
+        feeGranter,
         feePayer,
       );
       const signDoc1 = makeSignDoc(txBodyBytes, authInfoBytes1, chainId, accountNumber1);
@@ -502,6 +513,7 @@ describe("StargateClient", () => {
         [{ pubkey, sequence: sequence2 }],
         feeAmount,
         gasLimit,
+        feeGranter,
         feePayer,
       );
       const signDoc2 = makeSignDoc(txBodyBytes, authInfoBytes2, chainId, accountNumber2);

--- a/packages/stargate/src/stargateclient.spec.ts
+++ b/packages/stargate/src/stargateclient.spec.ts
@@ -419,7 +419,13 @@ describe("StargateClient", () => {
       const feeAmount = coins(2000, "ucosm");
       const gasLimit = 200000;
       const feePayer = "";
-      const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit, feePayer, sequence);
+      const authInfoBytes = makeAuthInfoBytes(
+        [{ pubkey, sequence }],
+        feeAmount,
+        gasLimit,
+        feePayer,
+        sequence,
+      );
 
       const chainId = await client.getChainId();
       const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
@@ -473,7 +479,12 @@ describe("StargateClient", () => {
       const feePayer = "";
 
       const { accountNumber: accountNumber1, sequence: sequence1 } = (await client.getSequence(address))!;
-      const authInfoBytes1 = makeAuthInfoBytes([{ pubkey, sequence: sequence1 }], feeAmount, gasLimit, feePayer);
+      const authInfoBytes1 = makeAuthInfoBytes(
+        [{ pubkey, sequence: sequence1 }],
+        feeAmount,
+        gasLimit,
+        feePayer,
+      );
       const signDoc1 = makeSignDoc(txBodyBytes, authInfoBytes1, chainId, accountNumber1);
       const { signature: signature1 } = await wallet.signDirect(address, signDoc1);
       const txRaw1 = TxRaw.fromPartial({
@@ -487,7 +498,12 @@ describe("StargateClient", () => {
       assertIsDeliverTxSuccess(txResult);
 
       const { accountNumber: accountNumber2, sequence: sequence2 } = (await client.getSequence(address))!;
-      const authInfoBytes2 = makeAuthInfoBytes([{ pubkey, sequence: sequence2 }], feeAmount, gasLimit, feePayer);
+      const authInfoBytes2 = makeAuthInfoBytes(
+        [{ pubkey, sequence: sequence2 }],
+        feeAmount,
+        gasLimit,
+        feePayer,
+      );
       const signDoc2 = makeSignDoc(txBodyBytes, authInfoBytes2, chainId, accountNumber2);
       const { signature: signature2 } = await wallet.signDirect(address, signDoc2);
       const txRaw2 = TxRaw.fromPartial({

--- a/packages/stargate/src/testutils.spec.ts
+++ b/packages/stargate/src/testutils.spec.ts
@@ -234,8 +234,8 @@ export class ModifyingDirectSecp256k1HdWallet extends DirectSecp256k1HdWallet {
     }));
     const modifiedFeeAmount = coins(3000, "ucosm");
     const modifiedGasLimit = 333333;
-    const modifiedFeeGranter = "";
-    const modifiedFeePayer = "";
+    const modifiedFeeGranter = undefined;
+    const modifiedFeePayer = undefined;
     const modifiedSignDoc = {
       ...signDoc,
       bodyBytes: Uint8Array.from(TxBody.encode(modifiedTxBody).finish()),

--- a/packages/stargate/src/testutils.spec.ts
+++ b/packages/stargate/src/testutils.spec.ts
@@ -234,6 +234,7 @@ export class ModifyingDirectSecp256k1HdWallet extends DirectSecp256k1HdWallet {
     }));
     const modifiedFeeAmount = coins(3000, "ucosm");
     const modifiedGasLimit = 333333;
+    const modifiedFeeGranter = "";
     const modifiedFeePayer = "";
     const modifiedSignDoc = {
       ...signDoc,
@@ -242,6 +243,7 @@ export class ModifyingDirectSecp256k1HdWallet extends DirectSecp256k1HdWallet {
         signers,
         modifiedFeeAmount,
         modifiedGasLimit,
+        modifiedFeeGranter,
         modifiedFeePayer,
         SignMode.SIGN_MODE_DIRECT,
       ),

--- a/packages/stargate/src/testutils.spec.ts
+++ b/packages/stargate/src/testutils.spec.ts
@@ -234,6 +234,7 @@ export class ModifyingDirectSecp256k1HdWallet extends DirectSecp256k1HdWallet {
     }));
     const modifiedFeeAmount = coins(3000, "ucosm");
     const modifiedGasLimit = 333333;
+    const modifiedFeePayer = "";
     const modifiedSignDoc = {
       ...signDoc,
       bodyBytes: Uint8Array.from(TxBody.encode(modifiedTxBody).finish()),
@@ -241,6 +242,7 @@ export class ModifyingDirectSecp256k1HdWallet extends DirectSecp256k1HdWallet {
         signers,
         modifiedFeeAmount,
         modifiedGasLimit,
+        modifiedFeePayer,
         SignMode.SIGN_MODE_DIRECT,
       ),
     };


### PR DESCRIPTION
This PR involves allowing users to set an account as FeePayer, as it is needed for the transaction type `/osmos.authz.v1beta1.MsgExec` to execute. 

Reference Issue: https://github.com/cosmos/cosmjs/issues/1155