### PR TITLE
Fix BondStatusString values (backport to 0.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- @cosmjs/stargate: Fix valid values of `BondStatusString` for `validators`
+  query ([#1170]).
+
+[#1170]: https://github.com/cosmos/cosmjs/issues/1170
+
 ## [0.28.6] - 2022-06-08
 
 ## [0.28.5] - 2022-06-08

--- a/packages/stargate/src/modules/staking/queries.ts
+++ b/packages/stargate/src/modules/staking/queries.ts
@@ -21,7 +21,14 @@ import Long from "long";
 
 import { createPagination, createProtobufRpcClient, QueryClient } from "../../queryclient";
 
-export type BondStatusString = Exclude<keyof typeof BondStatus, "BOND_STATUS_UNSPECIFIED">;
+// It's an enum in Go and a string in the protobuf API. "BOND_STATUS_UNSPECIFIED"
+// is excluded and "" is supported instead 🤷.
+//
+// String values: https://github.com/cosmos/cosmos-sdk/blob/v0.45.5/x/staking/types/staking.pb.go#L57-L62
+// Validation: https://github.com/cosmos/cosmos-sdk/blob/v0.45.5/x/staking/keeper/grpc_query.go#L29-L32
+export type BondStatusString =
+  | keyof Pick<typeof BondStatus, "BOND_STATUS_BONDED" | "BOND_STATUS_UNBONDED" | "BOND_STATUS_UNBONDING">
+  | "";
 
 export interface StakingExtension {
   readonly staking: {


### PR DESCRIPTION
Backport of #1171 (see https://github.com/cosmos/cosmjs/issues/1170)