### PR TITLE
Lazy loading `ValidatorUpdate.votingPower`

### DIFF
--- a/packages/tendermint-rpc/src/tendermint34/adaptor/responses.ts
+++ b/packages/tendermint-rpc/src/tendermint34/adaptor/responses.ts
@@ -263,7 +263,10 @@ interface RpcValidatorUpdate {
 export function decodeValidatorUpdate(data: RpcValidatorUpdate): responses.ValidatorUpdate {
   return {
     pubkey: decodePubkey(assertObject(data.pub_key)),
-    votingPower: Integer.parse(assertNotEmpty(data.power)),
+    get votingPower() {
+      delete (this as any).votingPower;
+      return (this as any).votingPower = Integer.parse(assertNotEmpty(data.power))
+    },
   };
 }
 


### PR DESCRIPTION
For some reason this block on Juno has a validator update with out a power value. https://www.mintscan.io/juno/blocks/3103475.

This causes `Tendermint34Client.blockResults` to throw an error, I have changed the decoding to have [lazy memoized](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get#smart_self-overwriting_lazy_getters) so only if you want to access the validator updates power property it will throw an error.

Raw request: `curl --location --request GET 'https://rpc.juno-1.beta.api.onfinality.io/block_results?height=3103475'`

Minimised response:
```
{
    "jsonrpc": "2.0",
    "id": -1,
    "result": {
        "height": "3103475",
        "txs_results": [....],
        "begin_block_events": [....],
        "end_block_events": [....],
        "validator_updates": [
            {
                "pub_key": {
                    "Sum": {
                        "type": "tendermint.crypto.PublicKey_Ed25519",
                        "value": {
                            "ed25519": "Gi1hPuzHZegDIkB7Jhrg6Z6UOAvR9qf2Ll1FRFlQmTA="
                        }
                    }
                },
                "power": "329"
            },
            {
                "pub_key": {
                    "Sum": {
                        "type": "tendermint.crypto.PublicKey_Ed25519",
                        "value": {
                            "ed25519": "1fp3zs+TP2NUt4HTvWjjH+6/jUKFHZT9Xrzk3CIfkpg="
                        }
                    }
                }
            }
        ],
        "consensus_param_updates": {
            "block": {
                "max_bytes": "22020096",
                "max_gas": "100000000"
            },
            "evidence": {
                "max_age_num_blocks": "100000",
                "max_age_duration": "172800000000000",
                "max_bytes": "1048576"
            },
            "validator": {
                "pub_key_types": [
                    "ed25519"
                ]
            }
        }
    }
}
```