### PR TITLE
Fix allow optional attributes on decodeAttributes

### DIFF
--- a/packages/tendermint-rpc/src/tendermint34/adaptor/responses.ts
+++ b/packages/tendermint-rpc/src/tendermint34/adaptor/responses.ts
@@ -111,7 +111,7 @@ function decodeAttribute(attribute: RpcAttribute): responses.Attribute {
 }
 
 function decodeAttributes(attributes: readonly RpcAttribute[]): responses.Attribute[] {
-  return assertArray(attributes).map(decodeAttribute);
+  return assertArray(optional<readonly RpcAttribute[]>(attributes, [])).map(decodeAttribute);
 }
 
 interface RpcEvent {


### PR DESCRIPTION
Empty events emitted will result in missing attributes field in events object, which is a legit scenario.

```json
{
   "type": "cosmos.module.EmittedEvent"
}
```
Which causes decodeAttributes assertArray throw an exception `UnhandledPromiseRejectionWarning: Error: Value must not be undefined`. I'm proposing to make this field optional.
