### PR TITLE
timeout check uses microseconds

### DIFF
--- a/packages/faucet/src/api/webserver.ts
+++ b/packages/faucet/src/api/webserver.ts
@@ -67,7 +67,7 @@ export class Webserver {
 
           const entry = this.addressCounter.get(address);
           if (entry !== undefined) {
-            if (entry.getTime() + 24 * 3600 > Date.now()) {
+            if (entry.getTime() + 24 * 3600 * 1000 > Date.now()) {
               throw new HttpError(
                 405,
                 "Too many request from the same address. Blocked to prevent draining. Please wait 24h and try it again!",


### PR DESCRIPTION
the time delay for requests was not working.
the time comparison is done in micro seconds so the amount added to the time needs to be in microseconds. 
I added in a * 1000 and it works now.