### PR TITLE
Minor broken link when reading on NPM's site

### DIFF
--- a/packages/cli/MASK.md
+++ b/packages/cli/MASK.md
@@ -219,10 +219,10 @@ native messages to make this binding simpler, and also allow these to be
 triggered by internal contract logic (they cannot form opaque messages, but
 rather just relay opaque messages formed by the clients).
 
-## Transfering Owner
+## Transferring Owner
 
 Happy hacking using the mask contract. And to make this a bit more interesting,
-note that you can transfer control of this mask. By transfering ownership, we
+note that you can transfer control of this mask. By transferring ownership, we
 transfer control of our `ucosm` native , our `FOO` erc20 token, and our open
 staking position in one fell swoop, without the other modules/contracts being
 aware of the change.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -259,7 +259,7 @@ play with contracts.
 
 ## Diving into Contracts
 
-Check out the [mask documentation](./MASK.md) to view how to use some custom
+Check out the [mask documentation](https://github.com/cosmos/cosmjs/blob/main/packages/cli/MASK.md) to view how to use some custom
 helpers to upload code and use non-trivial contracts with proper types.
 
 ## License


### PR DESCRIPTION
When visiting the site:
https://www.npmjs.com/package/@cosmjs/cli

Near the bottom there's a broken link, perhaps because it used a relative path. Just set that to the long-form URL so it won't 404 on anyone.

Then also a little typo.