### PR TITLE
fix: return tx response data without ignoring it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,13 @@ and this project adheres to
 - @cosmjs/tendermint-rpc: Fix `key` and `value` type in `RpcAbciQueryResponse`
   to also include the `null` option.
 - @cosmjs/tendermint-rpc: Fix decoding events without attributes ([#1198]).
+- @cosmjs/stargate: Return tx response data without ignoring it ([#1241]).
 
 [#1170]: https://github.com/cosmos/cosmjs/issues/1170
 [#1177]: https://github.com/cosmos/cosmjs/issues/1177
 [#1188]: https://github.com/cosmos/cosmjs/pull/1188
 [#1198]: https://github.com/cosmos/cosmjs/pull/1198
+[#1241]: https://github.com/cosmos/cosmjs/pull/1241
 
 ### Changed
 

--- a/packages/stargate/src/stargateclient.spec.ts
+++ b/packages/stargate/src/stargateclient.spec.ts
@@ -381,7 +381,12 @@ describe("StargateClient", () => {
       const { gasUsed, rawLog, data, transactionHash } = txResult;
       expect(gasUsed).toBeGreaterThan(0);
       expect(rawLog).toMatch(/{"key":"amount","value":"1234567ucosm"}/);
-      expect(data).toEqual([{ msgType: "/cosmos.bank.v1beta1.MsgSend", data: new Uint8Array() }]); // MsgSendResponse is empty
+      // MsgSendResponse is empty
+      if (simapp44Enabled()) {
+        expect(data).toEqual([{ msgType: "/cosmos.bank.v1beta1.MsgSend", data: new Uint8Array() }]);
+      } else {
+        expect(data).toBeUndefined();
+      }
       expect(transactionHash).toMatch(/^[0-9A-F]{64}$/);
 
       client.disconnect();

--- a/packages/stargate/src/stargateclient.spec.ts
+++ b/packages/stargate/src/stargateclient.spec.ts
@@ -385,7 +385,7 @@ describe("StargateClient", () => {
       if (simapp44Enabled()) {
         expect(data).toEqual([{ msgType: "/cosmos.bank.v1beta1.MsgSend", data: new Uint8Array() }]);
       } else {
-        expect(data).toBeUndefined();
+        expect(data).toEqual([]);
       }
       expect(transactionHash).toMatch(/^[0-9A-F]{64}$/);
 

--- a/packages/stargate/src/stargateclient.spec.ts
+++ b/packages/stargate/src/stargateclient.spec.ts
@@ -378,71 +378,10 @@ describe("StargateClient", () => {
       const txResult = await client.broadcastTx(txRawBytes);
       assertIsDeliverTxSuccess(txResult);
 
-      const { gasUsed, rawLog, transactionHash } = txResult;
+      const { gasUsed, rawLog, data, transactionHash } = txResult;
       expect(gasUsed).toBeGreaterThan(0);
       expect(rawLog).toMatch(/{"key":"amount","value":"1234567ucosm"}/);
-      expect(transactionHash).toMatch(/^[0-9A-F]{64}$/);
-
-      client.disconnect();
-    });
-
-    it("broadcasts a transaction, and get a response data", async () => {
-      pendingWithoutSimapp();
-      const client = await StargateClient.connect(simapp.tendermintUrl);
-      const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic);
-      const [{ address, pubkey: pubkeyBytes }] = await wallet.getAccounts();
-      const pubkey = encodePubkey({
-        type: "tendermint/PubKeySecp256k1",
-        value: toBase64(pubkeyBytes),
-      });
-      const registry = new Registry();
-
-      const proposalContent: EncodeObject = {
-        typeUrl: "/cosmos.gov.v1beta1.TextProposal",
-        value: {
-          title: "hello",
-          description: "world",
-        },
-      };
-      const txBodyFields: TxBodyEncodeObject = {
-        typeUrl: "/cosmos.tx.v1beta1.TxBody",
-        value: {
-          messages: [
-            {
-              typeUrl: "/cosmos.gov.v1beta1.MsgSubmitProposal",
-              value: {
-                content: registry.encodeAsAny(proposalContent),
-                initialDeposit: {
-                  denom: "ucosm",
-                  amount: "1",
-                },
-                proposer: address,
-              },
-            },
-          ],
-        },
-      };
-      const txBodyBytes = registry.encode(txBodyFields);
-      const { accountNumber, sequence } = (await client.getSequence(address))!;
-      const feeAmount = coins(2000, "ucosm");
-      const gasLimit = 200000;
-      const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence }], feeAmount, gasLimit);
-
-      const chainId = await client.getChainId();
-      const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, accountNumber);
-      const { signature } = await wallet.signDirect(address, signDoc);
-      const txRaw = TxRaw.fromPartial({
-        bodyBytes: txBodyBytes,
-        authInfoBytes: authInfoBytes,
-        signatures: [fromBase64(signature.signature)],
-      });
-      const txRawBytes = Uint8Array.from(TxRaw.encode(txRaw).finish());
-      const txResult = await client.broadcastTx(txRawBytes);
-      assertIsDeliverTxSuccess(txResult);
-
-      const { gasUsed, rawLog, transactionHash } = txResult;
-      expect(gasUsed).toBeGreaterThan(0);
-      expect(rawLog).toMatch(/{"key":"amount","value":"1234567ucosm"}/);
+      expect(data).toEqual([{ msgType: "/cosmos.bank.v1beta1.MsgSend", data: new Uint8Array() }]); // MsgSendResponse is empty
       expect(transactionHash).toMatch(/^[0-9A-F]{64}$/);
 
       client.disconnect();

--- a/packages/stargate/src/stargateclient.spec.ts
+++ b/packages/stargate/src/stargateclient.spec.ts
@@ -381,7 +381,7 @@ describe("StargateClient", () => {
       const { gasUsed, rawLog, data, transactionHash } = txResult;
       expect(gasUsed).toBeGreaterThan(0);
       expect(rawLog).toMatch(/{"key":"amount","value":"1234567ucosm"}/);
-      // MsgSendResponse is empty
+      // MsgSendResponse is empty.
       if (simapp44Enabled()) {
         expect(data).toEqual([{ msgType: "/cosmos.bank.v1beta1.MsgSend", data: new Uint8Array() }]);
       } else {

--- a/packages/stargate/src/stargateclient.ts
+++ b/packages/stargate/src/stargateclient.ts
@@ -8,6 +8,7 @@ import { MsgData } from "cosmjs-types/cosmos/base/abci/v1beta1/abci";
 import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
 import { QueryDelegatorDelegationsResponse } from "cosmjs-types/cosmos/staking/v1beta1/query";
 import { DelegationResponse } from "cosmjs-types/cosmos/staking/v1beta1/staking";
+import { TxMsgData } from "cosmjs-types/cosmos/base/abci/v1beta1/abci";
 
 import { Account, accountFromAny, AccountParser } from "./accounts";
 import {
@@ -65,6 +66,7 @@ export interface IndexedTx {
   /** Transaction execution error code. 0 on success. */
   readonly code: number;
   readonly rawLog: string;
+  readonly data?: Uint8Array;
   /**
    * Raw transaction bytes stored in Tendermint.
    *
@@ -418,6 +420,7 @@ export class StargateClient {
             code: result.code,
             height: result.height,
             rawLog: result.rawLog,
+            data: TxMsgData.decode(result.data!).data ?? null,
             transactionHash: txId,
             gasUsed: result.gasUsed,
             gasWanted: result.gasWanted,
@@ -454,6 +457,7 @@ export class StargateClient {
         hash: toHex(tx.hash).toUpperCase(),
         code: tx.result.code,
         rawLog: tx.result.log || "",
+        data: tx.result.data,
         tx: tx.tx,
         gasUsed: tx.result.gasUsed,
         gasWanted: tx.result.gasWanted,

--- a/packages/stargate/src/stargateclient.ts
+++ b/packages/stargate/src/stargateclient.ts
@@ -420,7 +420,7 @@ export class StargateClient {
             code: result.code,
             height: result.height,
             rawLog: result.rawLog,
-            data: TxMsgData.decode(result.data!).data ?? null,
+            data: result.data ? TxMsgData.decode(result.data).data : undefined,
             transactionHash: txId,
             gasUsed: result.gasUsed,
             gasWanted: result.gasWanted,

--- a/packages/stargate/src/stargateclient.ts
+++ b/packages/stargate/src/stargateclient.ts
@@ -4,11 +4,10 @@ import { toHex } from "@cosmjs/encoding";
 import { Uint53 } from "@cosmjs/math";
 import { HttpEndpoint, Tendermint34Client, toRfc3339WithNanoseconds } from "@cosmjs/tendermint-rpc";
 import { assert, sleep } from "@cosmjs/utils";
-import { MsgData } from "cosmjs-types/cosmos/base/abci/v1beta1/abci";
+import { MsgData, TxMsgData } from "cosmjs-types/cosmos/base/abci/v1beta1/abci";
 import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
 import { QueryDelegatorDelegationsResponse } from "cosmjs-types/cosmos/staking/v1beta1/query";
 import { DelegationResponse } from "cosmjs-types/cosmos/staking/v1beta1/staking";
-import { TxMsgData } from "cosmjs-types/cosmos/base/abci/v1beta1/abci";
 
 import { Account, accountFromAny, AccountParser } from "./accounts";
 import {


### PR DESCRIPTION
The `DeliverTxRepsonse` interface already has a [data](https://github.com/cosmos/cosmjs/blob/e514144e48ff74c8741f08c86c876bc54ffdf361/packages/stargate/src/stargateclient.ts#L102) field so that it can contain tx result data. But, it doesn't get the `data` and set it into the `DeliverTxResponse` when querying tx results internally. 

So, I fixed it to read `data` from tx results properly.