### PR TITLE
fix: update amino serialization with fix for regen message types

### DIFF
--- a/packages/amino/src/signdoc.ts
+++ b/packages/amino/src/signdoc.ts
@@ -69,5 +69,21 @@ export function makeSignDoc(
 }
 
 export function serializeSignDoc(signDoc: StdSignDoc): Uint8Array {
-  return toUtf8(sortedJsonStringify(signDoc));
+  const fixedMsgs = signDoc.msgs.map((aminoMsg) => {
+    if (aminoMsg.type.startsWith("regen")) {
+      // regen ledger incorrectly implements amino signing.
+      // this short term workaround makes cosmjs compatible with regen-ledger v4.0
+      // until regen ledger upgrades with the fix in v5.0
+      // ref: https://github.com/regen-network/regen-ledger/pull/1480
+      return aminoMsg.value
+    } else {
+      return aminoMsg
+    }
+  })
+
+  
+  var fixedSignDoc: any = signDoc;
+  fixedSignDoc.msgs = fixedMsgs;
+
+  return toUtf8(sortedJsonStringify(fixedSignDoc));
 }


### PR DESCRIPTION
This PR adds a custom serialization for amino messages that omits the type & value wrapper for Regen specific message types.

It is a workaround until https://github.com/regen-network/regen-ledger/pull/1480 get's released (targeting Regen Ledger v5.0, requiring a network upgrade).