### PR TITLE
Accept non-ASCII inputs in query requests of queryContractSmart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,12 +57,15 @@ and this project adheres to
 - @cosmjs/tendermint-rpc: Fix decoding events without attributes ([#1198]).
 - @cosmjs/amino, @cosmjs/proto-signing: Support amounts larger than the uint64
   range in `parseCoins` ([#1268]).
+- @cosmjs/cosmwasm-stargate: Accept non-ASCII inputs in query requests of
+  `{CosmWasmClient,WasmExtension}.queryContractSmart` ([#1269]).
 
 [#1170]: https://github.com/cosmos/cosmjs/issues/1170
 [#1177]: https://github.com/cosmos/cosmjs/issues/1177
 [#1188]: https://github.com/cosmos/cosmjs/pull/1188
 [#1198]: https://github.com/cosmos/cosmjs/pull/1198
 [#1268]: https://github.com/cosmos/cosmjs/issues/1268
+[#1269]: https://github.com/cosmos/cosmjs/issues/1269
 
 ### Changed
 

--- a/packages/cosmwasm-stargate/src/modules/wasm/queries.spec.ts
+++ b/packages/cosmwasm-stargate/src/modules/wasm/queries.spec.ts
@@ -1,5 +1,5 @@
 import { sha256 } from "@cosmjs/crypto";
-import { fromAscii, fromHex, toAscii, toHex } from "@cosmjs/encoding";
+import { fromAscii, fromHex, toAscii, toHex, toUtf8 } from "@cosmjs/encoding";
 import { DirectSecp256k1HdWallet, OfflineDirectSigner, Registry } from "@cosmjs/proto-signing";
 import {
   assertIsDeliverTxSuccess,
@@ -75,7 +75,7 @@ async function instantiateContract(
       sender: alice.address0,
       codeId: Long.fromNumber(codeId),
       label: "my escrow",
-      msg: toAscii(
+      msg: toUtf8(
         JSON.stringify({
           verifier: alice.address0,
           beneficiary: beneficiaryAddress,
@@ -108,7 +108,7 @@ async function executeContract(
     value: MsgExecuteContract.fromPartial({
       sender: alice.address0,
       contract: contractAddress,
-      msg: toAscii(JSON.stringify(msg)),
+      msg: toUtf8(JSON.stringify(msg)),
       funds: [],
     }),
   };
@@ -254,7 +254,7 @@ describe("WasmExtension", () => {
         jasmine.objectContaining({
           codeId: Long.fromNumber(hackatomCodeId, true),
           operation: ContractCodeHistoryOperationType.CONTRACT_CODE_HISTORY_OPERATION_TYPE_INIT,
-          msg: toAscii(
+          msg: toUtf8(
             JSON.stringify({
               verifier: alice.address0,
               beneficiary: beneficiaryAddress,

--- a/packages/cosmwasm-stargate/src/modules/wasm/queries.ts
+++ b/packages/cosmwasm-stargate/src/modules/wasm/queries.ts
@@ -1,4 +1,4 @@
-import { fromUtf8, toAscii } from "@cosmjs/encoding";
+import { fromUtf8, toUtf8 } from "@cosmjs/encoding";
 import { createPagination, createProtobufRpcClient, QueryClient } from "@cosmjs/stargate";
 import {
   QueryAllContractStateResponse,
@@ -117,7 +117,7 @@ export function setupWasmExtension(base: QueryClient): WasmExtension {
       },
 
       queryContractSmart: async (address: string, query: Record<string, unknown>) => {
-        const request = { address: address, queryData: toAscii(JSON.stringify(query)) };
+        const request = { address: address, queryData: toUtf8(JSON.stringify(query)) };
         const { data } = await queryService.SmartContractState(request);
         // By convention, smart queries must return a valid JSON document (see https://github.com/CosmWasm/cosmwasm/issues/144)
         let responseText: string;


### PR DESCRIPTION
Closes #1269