### PR TITLE
fix: fixed the cosmwasm msg types

### DIFF
--- a/packages/cosmwasm-stargate/src/cosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.ts
@@ -71,7 +71,7 @@ export interface ContractCodeHistoryEntry {
   /** The source of this history entry */
   readonly operation: "Genesis" | "Init" | "Migrate";
   readonly codeId: number;
-  readonly msg: Record<string, unknown>;
+  readonly msg: Object;
 }
 
 /** Use for testing only */
@@ -439,7 +439,7 @@ export class CosmWasmClient {
    * Promise is rejected for invalid query format.
    * Promise is rejected for invalid response format.
    */
-  public async queryContractSmart(address: string, queryMsg: Record<string, unknown>): Promise<JsonObject> {
+  public async queryContractSmart(address: string, queryMsg: Object): Promise<JsonObject> {
     try {
       return await this.forceGetQueryClient().wasm.queryContractSmart(address, queryMsg);
     } catch (error) {

--- a/packages/cosmwasm-stargate/src/cosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.ts
@@ -71,7 +71,7 @@ export interface ContractCodeHistoryEntry {
   /** The source of this history entry */
   readonly operation: "Genesis" | "Init" | "Migrate";
   readonly codeId: number;
-  readonly msg: Object;
+  readonly msg: Record<string, unknown>;
 }
 
 /** Use for testing only */
@@ -439,7 +439,7 @@ export class CosmWasmClient {
    * Promise is rejected for invalid query format.
    * Promise is rejected for invalid response format.
    */
-  public async queryContractSmart(address: string, queryMsg: Object): Promise<JsonObject> {
+  public async queryContractSmart(address: string, queryMsg: Record<string, unknown>): Promise<JsonObject> {
     try {
       return await this.forceGetQueryClient().wasm.queryContractSmart(address, queryMsg);
     } catch (error) {

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -137,7 +137,7 @@ export interface MigrateResult {
 
 export interface ExecuteInstruction {
   contractAddress: string;
-  msg: Record<string, unknown>;
+  msg: Object;
   funds?: readonly Coin[];
 }
 
@@ -278,7 +278,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
   public async instantiate(
     senderAddress: string,
     codeId: number,
-    msg: Record<string, unknown>,
+    msg: Object,
     label: string,
     fee: StdFee | "auto" | number,
     options: InstantiateOptions = {},
@@ -368,7 +368,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     senderAddress: string,
     contractAddress: string,
     codeId: number,
-    migrateMsg: Record<string, unknown>,
+    migrateMsg: Object,
     fee: StdFee | "auto" | number,
     memo = "",
   ): Promise<MigrateResult> {
@@ -397,7 +397,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
   public async execute(
     senderAddress: string,
     contractAddress: string,
-    msg: Record<string, unknown>,
+    msg: Object,
     fee: StdFee | "auto" | number,
     memo = "",
     funds?: readonly Coin[],

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -369,7 +369,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     senderAddress: string,
     contractAddress: string,
     codeId: number,
-    migratemsg: JsonObject,
+    migrateMsg: JsonObject,
     fee: StdFee | "auto" | number,
     memo = "",
   ): Promise<MigrateResult> {

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -57,6 +57,7 @@ import {
   MsgStoreCodeEncodeObject,
   MsgUpdateAdminEncodeObject,
   wasmTypes,
+  JsonObject,
 } from "./modules";
 
 export interface UploadResult {
@@ -137,7 +138,7 @@ export interface MigrateResult {
 
 export interface ExecuteInstruction {
   contractAddress: string;
-  msg: Object;
+  msg: JsonObject;
   funds?: readonly Coin[];
 }
 
@@ -278,7 +279,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
   public async instantiate(
     senderAddress: string,
     codeId: number,
-    msg: Object,
+    msg: JsonObject,
     label: string,
     fee: StdFee | "auto" | number,
     options: InstantiateOptions = {},
@@ -368,7 +369,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     senderAddress: string,
     contractAddress: string,
     codeId: number,
-    migrateMsg: Object,
+    migratemsg: JsonObject,
     fee: StdFee | "auto" | number,
     memo = "",
   ): Promise<MigrateResult> {
@@ -397,7 +398,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
   public async execute(
     senderAddress: string,
     contractAddress: string,
-    msg: Object,
+    msg: JsonObject,
     fee: StdFee | "auto" | number,
     memo = "",
     funds?: readonly Coin[],


### PR DESCRIPTION
The typescript file of messages using new macro `cw_serde` then generated by codegen are no longer fix `Record<string, unknown>`. The msg types should be `JsonObject`, instead.

The reason is as follows:
1. schema json changed to have value `"additionalProperties": false` by this [change](https://github.com/CosmWasm/cw-nfts/commit/6dfb0c6f020b417620708a615f19828929f01cdb#diff-4244bdf6e15adf9c0a9e27dd191357efb818a9d2a25eff4d10a9b1fa1aeccd46R24) in `cw_nfts`
2. codegen ts structure loses `[k: string]: unknown`, it can be found at [cw721-base-instantiate-with-cw-serde](https://github.com/desmos-labs/contract-utils/blob/paul/DCD-83/add-remarkables-utils/types/contracts/cw721-poap/instantiate_msg.d.ts) and [cw721-poap-instantiate-without-cw-serde](https://github.com/desmos-labs/contract-utils/blob/paul/DCD-83/add-remarkables-utils/types/contracts/cw721-base/instantiate_msg.d.ts)
3. without `[k: string]: unknown` field, message is no longer to match `Record<string, unknown>`