### PR TITLE
change import pattern of crypto, to allow import error to be caught a…

### DIFF
--- a/packages/crypto/src/pbkdf2.ts
+++ b/packages/crypto/src/pbkdf2.ts
@@ -11,9 +11,9 @@ import { sha512 as nobleSha512 } from "@noble/hashes/sha512";
  */
 export async function getCryptoModule(): Promise<any | undefined> {
   try {
-    const crypto = await import("crypto");
+    const crypto = await require("crypto");
     // We get `Object{default: Object{}}` as a fallback when using
-    // `crypto: false` in Webpack 5, which we interprete as unavailable.
+    // `crypto: false` in Webpack 5, which we interpret as unavailable.
     if (typeof crypto === "object" && Object.keys(crypto).length <= 1) {
       return undefined;
     }
@@ -25,14 +25,17 @@ export async function getCryptoModule(): Promise<any | undefined> {
 
 export async function getSubtle(): Promise<any | undefined> {
   const g: any = globalThis;
-  let subtle = g.crypto && g.crypto.subtle;
-  if (!subtle) {
-    const crypto = await getCryptoModule();
-    if (crypto && crypto.webcrypto && crypto.webcrypto.subtle) {
-      subtle = crypto.webcrypto.subtle;
-    }
+  let crypto;
+  if (!g.crypto) {
+    crypto = await getCryptoModule();
+  } else {
+    crypto = g.crypto;
   }
-  return subtle;
+  if (crypto && crypto.subtle) {
+    return crypto.subtle;
+  } else if (crypto.webcrypto && crypto.webcrypto.subtle) {
+    return crypto.webcrypto.subtle;
+  }
 }
 
 export async function pbkdf2Sha512Subtle(

--- a/packages/stargate/src/modules/authz/queries.ts
+++ b/packages/stargate/src/modules/authz/queries.ts
@@ -10,6 +10,8 @@ export interface AuthzExtension {
       msgTypeUrl: string,
       paginationKey?: Uint8Array,
     ) => Promise<QueryGrantsResponse>;
+    readonly granteeGrants: (grantee: string, paginationKey?: Uint8Array) => Promise<QueryGrantsResponse>;
+    readonly granterGrants: (granter: string, paginationKey?: Uint8Array) => Promise<QueryGrantsResponse>;
   };
 }
 
@@ -22,14 +24,24 @@ export function setupAuthzExtension(base: QueryClient): AuthzExtension {
   return {
     authz: {
       grants: async (granter: string, grantee: string, msgTypeUrl: string, paginationKey?: Uint8Array) => {
-        const response = await queryService.Grants({
+        return await queryService.Grants({
           granter: granter,
           grantee: grantee,
           msgTypeUrl: msgTypeUrl,
           pagination: createPagination(paginationKey),
         });
-
-        return response;
+      },
+      granteeGrants: async (grantee: string, paginationKey?: Uint8Array) => {
+        return await queryService.GranteeGrants({
+          grantee: grantee,
+          pagination: createPagination(paginationKey),
+        });
+      },
+      granterGrants: async (granter: string, paginationKey?: Uint8Array) => {
+        return await queryService.GranterGrants({
+          granter: granter,
+          pagination: createPagination(paginationKey),
+        });
       },
     },
   };


### PR DESCRIPTION
crypto import:
change import pattern of crypto, to allow import error to be caught and acted on. the current model fails in react native, not exactly sure why, but using require instead avoids the issue.

Changed the lookup for `subtle`. Currently, if `subtle` doesn't exist on the crypto library, cosmjs will attempt to reimport node crypto, even if a proper crypto was already shimmed in. The changeset will pull subtle if it exists, otherwise return undefined. `getCryptoModule` will only be called if `crypto` is not already set on window/this

authz queries:
add more authz grant queries to catch up to current authz module