### PR TITLE
Fix parse ContractCodeHistory msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- @cosmjs/cosmwasm-stargate: Fix `ContractCodeHistory` decoding when msg contains non-printable ASCII ([#1320]).
+
+[#1320]: https://github.com/cosmos/cosmjs/pull/1320
+
 ## [0.29.3] - 2022-10-25
 
 ### Added

--- a/packages/cosmwasm-stargate/src/cosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { fromAscii, toHex } from "@cosmjs/encoding";
+import { fromUtf8, toHex } from "@cosmjs/encoding";
 import { Uint53 } from "@cosmjs/math";
 import {
   Account,
@@ -415,7 +415,7 @@ export class CosmWasmClient {
       return {
         operation: operations[entry.operation],
         codeId: entry.codeId.toNumber(),
-        msg: JSON.parse(fromAscii(entry.msg)),
+        msg: JSON.parse(fromUtf8(entry.msg)),
       };
     });
   }


### PR DESCRIPTION
Error: `Cannot decode character that is out of printable ASCII range: 10`

msg:
```json
{
"name": "DAF TOKEN",
"symbol":"DAF",
"decimals": 6,
"token_price": "20000",
"initial_balances":[
{
"address":"juno1krr3krmt6ax3gj2f84568tprt43hve4y59v0th",
"amount":"1000000"
}

        ], "mint": {"minter": "juno1krr3krmt6ax3gj2f84568tprt43hve4y59v0th", "cap": "10000000000" }}    
```

contract: [juno1mqk54m06stdxsnjrl69y97yp0fws299f3w9wa0zg3jzz8pzr6z9q0fr07s](https://blueprints.juno.giansalex.dev/#/contracts/juno1mqk54m06stdxsnjrl69y97yp0fws299f3w9wa0zg3jzz8pzr6z9q0fr07s)