### PR TITLE
Fix app crashing error

### DIFF
--- a/packages/socket/src/socketwrapper.ts
+++ b/packages/socket/src/socketwrapper.ts
@@ -60,6 +60,8 @@ export class SocketWrapper {
     this.connected = new Promise((resolve, reject) => {
       this.connectedResolver = resolve;
       this.connectedRejecter = reject;
+    }).catch((e) => {
+       console.log("Caught Error: SocketWrapper.connected rejected.",e)
     });
 
     this.url = url;


### PR DESCRIPTION
UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch().

This error will cause nodejs to crash when the connection times out. Firewalls will cause timeout.

Error could be gracefully handled.