### PR TITLE
Add default stargaze amino types to cosmwasm client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,16 @@ and this project adheres to
   `createWasmAminoConverters()` instead.
 - @cosmjs/encoding: Remove previously deprecated `Bech32` class. Please replace
   `Bech32.encode`/`.decode` with free the functions `toBech32`/`fromBech32`.
+- @cosmjs/cosmwasm-stargate: Changed the `SigningCosmWasmClient` constructor to
+  include all Amino type converters that the `SigningStargateClient` uses by
+  default, to match the default registry types ([#1384]).
 
 [#1002]: https://github.com/cosmos/cosmjs/issues/1002
 [#1240]: https://github.com/cosmos/cosmjs/pull/1240
 [#1289]: https://github.com/cosmos/cosmjs/issues/1289
 [#1291]: https://github.com/cosmos/cosmjs/issues/1291
 [#1329]: https://github.com/cosmos/cosmjs/pull/1329
+[#1384]: https://github.com/cosmos/cosmjs/pull/1384
 
 ### Added
 
@@ -54,11 +58,15 @@ and this project adheres to
   addresses for Instantiate2 ([#1253]).
 - @cosmjs/stargate: Add `txIndex` to `DeliverTxResponse` and `IndexedTx`
   ([#1361]).
+- @cosmjs/stargate: Add `createDefaultAminoConverters` to access the
+  `SigningStargateClient`'s list of default Amino type converters to match the
+  default registry types in `defaultStargateTypes` ([#1384]).
 
 [#1253]: https://github.com/cosmos/cosmjs/pull/1253
 [#1308]: https://github.com/cosmos/cosmjs/pull/1308
 [#1361]: https://github.com/cosmos/cosmjs/issues/1361
 [#1376]: https://github.com/cosmos/cosmjs/pull/1376
+[#1384]: https://github.com/cosmos/cosmjs/pull/1384
 
 ## [0.29.5] - 2022-12-07
 

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -162,17 +162,6 @@ function createDeliverTxResponseErrorMessage(result: DeliverTxResponse): string 
   return `Error when broadcasting tx ${result.transactionHash} at height ${result.height}. Code: ${result.code}; Raw log: ${result.rawLog}`;
 }
 
-function createDefaultRegistry(): Registry {
-  return new Registry([...defaultStargateTypes, ...wasmTypes]);
-}
-
-function createDefaultAminoTypes(): AminoTypes {
-  return new AminoTypes({
-    ...createDefaultAminoConverters(),
-    ...createWasmAminoConverters(),
-  })
-}
-
 export interface SigningCosmWasmClientOptions {
   readonly registry?: Registry;
   readonly aminoTypes?: AminoTypes;
@@ -240,8 +229,14 @@ export class SigningCosmWasmClient extends CosmWasmClient {
   ) {
     super(tmClient);
     const {
-      registry = createDefaultRegistry(),
-      aminoTypes = createDefaultAminoTypes(),
+      registry = new Registry([
+        ...defaultStargateTypes,
+        ...wasmTypes
+      ]),
+      aminoTypes = new AminoTypes({
+        ...createDefaultAminoConverters(),
+        ...createWasmAminoConverters(),
+      }),
     } = options;
     this.registry = registry;
     this.aminoTypes = aminoTypes;

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -17,7 +17,7 @@ import {
   AminoTypes,
   calculateFee,
   Coin,
-  createBankAminoConverters,
+  createDefaultAminoConverters,
   defaultRegistryTypes as defaultStargateTypes,
   DeliverTxResponse,
   Event,
@@ -166,6 +166,13 @@ function createDefaultRegistry(): Registry {
   return new Registry([...defaultStargateTypes, ...wasmTypes]);
 }
 
+function createDefaultAminoTypes(): AminoTypes {
+  return new AminoTypes({
+    ...createDefaultAminoConverters(),
+    ...createWasmAminoConverters(),
+  })
+}
+
 export interface SigningCosmWasmClientOptions {
   readonly registry?: Registry;
   readonly aminoTypes?: AminoTypes;
@@ -234,7 +241,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     super(tmClient);
     const {
       registry = createDefaultRegistry(),
-      aminoTypes = new AminoTypes({ ...createWasmAminoConverters(), ...createBankAminoConverters() }),
+      aminoTypes = createDefaultAminoTypes(),
     } = options;
     this.registry = registry;
     this.aminoTypes = aminoTypes;

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -231,7 +231,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     const {
       registry = new Registry([
         ...defaultStargateTypes,
-        ...wasmTypes
+        ...wasmTypes,
       ]),
       aminoTypes = new AminoTypes({
         ...createDefaultAminoConverters(),

--- a/packages/stargate/src/index.ts
+++ b/packages/stargate/src/index.ts
@@ -123,6 +123,7 @@ export {
   SearchTxQuery,
 } from "./search";
 export {
+  createDefaultAminoConverters,
   defaultRegistryTypes,
   SignerData,
   SigningStargateClient,

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -92,7 +92,7 @@ export interface SigningStargateClientOptions extends StargateClientOptions {
   readonly gasPrice?: GasPrice;
 }
 
-function createDefaultTypes(): AminoConverters {
+export function createDefaultAminoConverters(): AminoConverters {
   return {
     ...createAuthzAminoConverters(),
     ...createBankAminoConverters(),
@@ -103,6 +103,10 @@ function createDefaultTypes(): AminoConverters {
     ...createFeegrantAminoConverters(),
     ...createVestingAminoConverters(),
   };
+}
+
+function createDefaultAminoTypes(): AminoTypes {
+  return new AminoTypes(createDefaultAminoConverters())
 }
 
 export class SigningStargateClient extends StargateClient {
@@ -163,7 +167,10 @@ export class SigningStargateClient extends StargateClient {
     options: SigningStargateClientOptions,
   ) {
     super(tmClient, options);
-    const { registry = createDefaultRegistry(), aminoTypes = new AminoTypes(createDefaultTypes()) } = options;
+    const {
+      registry = createDefaultRegistry(),
+      aminoTypes = createDefaultAminoTypes()
+    } = options;
     this.registry = registry;
     this.aminoTypes = aminoTypes;
     this.signer = signer;

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -161,7 +161,7 @@ export class SigningStargateClient extends StargateClient {
     super(tmClient, options);
     const {
       registry = new Registry(defaultRegistryTypes),
-      aminoTypes = new AminoTypes(createDefaultAminoConverters())
+      aminoTypes = new AminoTypes(createDefaultAminoConverters()),
     } = options;
     this.registry = registry;
     this.aminoTypes = aminoTypes;

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -64,10 +64,6 @@ export const defaultRegistryTypes: ReadonlyArray<[string, GeneratedType]> = [
   ...vestingTypes,
 ];
 
-function createDefaultRegistry(): Registry {
-  return new Registry(defaultRegistryTypes);
-}
-
 /**
  * Signing information for a single signer that is not included in the transaction.
  *
@@ -103,10 +99,6 @@ export function createDefaultAminoConverters(): AminoConverters {
     ...createFeegrantAminoConverters(),
     ...createVestingAminoConverters(),
   };
-}
-
-function createDefaultAminoTypes(): AminoTypes {
-  return new AminoTypes(createDefaultAminoConverters())
 }
 
 export class SigningStargateClient extends StargateClient {
@@ -168,8 +160,8 @@ export class SigningStargateClient extends StargateClient {
   ) {
     super(tmClient, options);
     const {
-      registry = createDefaultRegistry(),
-      aminoTypes = createDefaultAminoTypes()
+      registry = new Registry(defaultRegistryTypes),
+      aminoTypes = new AminoTypes(createDefaultAminoConverters())
     } = options;
     this.registry = registry;
     this.aminoTypes = aminoTypes;


### PR DESCRIPTION
The `SigningStargazeClient` exports its default registry types to be consumed by the `SigningCosmWasmClient`, with the wasm types added on top of the default registry. However, this was not being done for Amino types.

This PR exports the `SigningStargateClient`'s default amino types to be consumed by the `SigningCosmWasmClient`, adding the wasm amino types on top, following the same pattern.

We ran into this issue over at DAO DAO when someone tried to use `SigningCosmWasmClient` to vote on a governance proposal. The PR to fix that is here: https://github.com/DA0-DA0/dao-dao-ui/pull/1165
...though ideally I can undo that fix once this PR is merged and published.