### PR TITLE
Remove unnecessary pendingWithoutSimapp44Or46

### DIFF
--- a/packages/stargate/src/modules/authz/queries.spec.ts
+++ b/packages/stargate/src/modules/authz/queries.spec.ts
@@ -11,7 +11,7 @@ import {
   defaultSigningClientOptions,
   faucet,
   makeRandomAddress,
-  pendingWithoutSimapp44Or46,
+  pendingWithoutSimapp,
   pendingWithoutSimapp46,
   simapp,
   simapp44Enabled,
@@ -81,7 +81,7 @@ describe("AuthzExtension", () => {
 
   describe("grants", () => {
     it("works", async () => {
-      pendingWithoutSimapp44Or46();
+      pendingWithoutSimapp();
       const [client, tmClient] = await makeClientWithAuthz(simapp.tendermintUrl);
       const response = await client.authz.grants(granter1Address, grantee1Address, "");
       expect(response.grants.length).toEqual(1);

--- a/packages/stargate/src/modules/gov/messages.spec.ts
+++ b/packages/stargate/src/modules/gov/messages.spec.ts
@@ -12,7 +12,6 @@ import {
   faucet,
   nonNegativeIntegerMatcher,
   pendingWithoutSimapp,
-  pendingWithoutSimapp44Or46,
   simapp,
   simappEnabled,
   validator,
@@ -171,7 +170,7 @@ describe("gov messages", () => {
 
   describe("MsgVoteWeighted", () => {
     it("works", async () => {
-      pendingWithoutSimapp44Or46(); // MsgVoteWeighted does not yet exist in Cosmos SDK 0.42
+      pendingWithoutSimapp();
       assert(voterWallet);
       assert(proposalId, "Missing proposal ID");
       const client = await SigningStargateClient.connectWithSigner(simapp.tendermintUrl, voterWallet);
@@ -204,7 +203,7 @@ describe("gov messages", () => {
     });
 
     it("works with Amino JSON sign mode", async () => {
-      pendingWithoutSimapp44Or46(); // MsgVoteWeighted does not yet exist in Cosmos SDK 0.42
+      pendingWithoutSimapp();
       assert(voterWalletAmino);
       assert(proposalId, "Missing proposal ID");
       const client = await SigningStargateClient.connectWithSigner(simapp.tendermintUrl, voterWalletAmino);

--- a/packages/stargate/src/testutils.spec.ts
+++ b/packages/stargate/src/testutils.spec.ts
@@ -27,12 +27,6 @@ export function simappEnabled(): boolean {
   return simapp44Enabled() || simapp46Enabled();
 }
 
-export function pendingWithoutSimapp44Or46(): void {
-  if (!simapp44Enabled() && !simapp46Enabled()) {
-    return pending("Set SIMAPP{44,46}_ENABLED to enable Simapp based tests");
-  }
-}
-
 export function pendingWithoutSimapp46(): void {
   if (!simapp46Enabled()) {
     return pending("Set SIMAPP46_ENABLED to enable Simapp based tests");


### PR DESCRIPTION
This was needed when we tested against 0.42 backends