### PR TITLE
Support wasm/MsgInstantiateContract2

### DIFF
--- a/packages/cosmwasm-stargate/src/modules/wasm/aminomessages.spec.ts
+++ b/packages/cosmwasm-stargate/src/modules/wasm/aminomessages.spec.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { fromBase64, toUtf8 } from "@cosmjs/encoding";
+import { fromBase64, toBase64, toUtf8 } from "@cosmjs/encoding";
 import { AminoTypes, coins } from "@cosmjs/stargate";
 import {
   MsgClearAdmin,
   MsgExecuteContract,
   MsgInstantiateContract,
+  MsgInstantiateContract2,
   MsgMigrateContract,
   MsgStoreCode,
   MsgUpdateAdmin,
@@ -15,6 +16,7 @@ import {
   AminoMsgClearAdmin,
   AminoMsgExecuteContract,
   AminoMsgInstantiateContract,
+  AminoMsgInstantiateContract2,
   AminoMsgMigrateContract,
   AminoMsgStoreCode,
   AminoMsgUpdateAdmin,
@@ -95,6 +97,72 @@ describe("AminoTypes", () => {
             msg: { foo: "bar" },
             funds: coins(1234, "ucosm"),
             admin: undefined,
+          },
+        };
+        expect(aminoMsg).toEqual(expected);
+      }
+    });
+
+    it("works for MsgInstantiateContract2", () => {
+      // With admin
+      {
+        const msg: MsgInstantiateContract2 = {
+          sender: "cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6",
+          codeId: Long.fromString("12345"),
+          label: "sticky",
+          msg: toUtf8(`{"foo":"bar"}`),
+          funds: coins(1234, "ucosm"),
+          admin: "cosmos10dyr9899g6t0pelew4nvf4j5c3jcgv0r73qga5",
+          salt: toUtf8("salt"),
+          fixMsg: false,
+        };
+        const aminoMsg = new AminoTypes(createWasmAminoConverters()).toAmino({
+          typeUrl: "/cosmwasm.wasm.v1.MsgInstantiateContract2",
+          value: msg,
+        });
+        const expected: AminoMsgInstantiateContract2 = {
+          type: "wasm/MsgInstantiateContract2",
+          value: {
+            sender: "cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6",
+            code_id: "12345",
+            label: "sticky",
+            msg: { foo: "bar" },
+            funds: coins(1234, "ucosm"),
+            admin: "cosmos10dyr9899g6t0pelew4nvf4j5c3jcgv0r73qga5",
+            salt: toBase64(toUtf8("salt")),
+            fix_msg: false,
+          },
+        };
+        expect(aminoMsg).toEqual(expected);
+      }
+
+      // Without admin
+      {
+        const msg: MsgInstantiateContract2 = {
+          sender: "cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6",
+          codeId: Long.fromString("12345"),
+          label: "sticky",
+          msg: toUtf8(`{"foo":"bar"}`),
+          funds: coins(1234, "ucosm"),
+          admin: "",
+          salt: toUtf8("salt"),
+          fixMsg: false,
+        };
+        const aminoMsg = new AminoTypes(createWasmAminoConverters()).toAmino({
+          typeUrl: "/cosmwasm.wasm.v1.MsgInstantiateContract2",
+          value: msg,
+        });
+        const expected: AminoMsgInstantiateContract2 = {
+          type: "wasm/MsgInstantiateContract2",
+          value: {
+            sender: "cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6",
+            code_id: "12345",
+            label: "sticky",
+            msg: { foo: "bar" },
+            funds: coins(1234, "ucosm"),
+            admin: undefined,
+            salt: toBase64(toUtf8("salt")),
+            fix_msg: false,
           },
         };
         expect(aminoMsg).toEqual(expected);

--- a/packages/cosmwasm-stargate/src/modules/wasm/aminomessages.ts
+++ b/packages/cosmwasm-stargate/src/modules/wasm/aminomessages.ts
@@ -5,6 +5,7 @@ import {
   MsgClearAdmin,
   MsgExecuteContract,
   MsgInstantiateContract,
+  MsgInstantiateContract2,
   MsgMigrateContract,
   MsgStoreCode,
   MsgUpdateAdmin,
@@ -70,6 +71,32 @@ export interface AminoMsgInstantiateContract {
     readonly funds: readonly Coin[];
     /** Bech32-encoded admin address */
     readonly admin?: string;
+  };
+}
+
+/**
+ * The Amino JSON representation of [MsgInstantiateContract2].
+ *
+ * [MsgInstantiateContract2]: https://github.com/CosmWasm/wasmd/blob/v0.31.0/proto/cosmwasm/wasm/v1/tx.proto#L76-L99
+ */
+export interface AminoMsgInstantiateContract2 {
+  type: "wasm/MsgInstantiateContract2";
+  value: {
+    /** Bech32 account address */
+    readonly sender: string;
+    /** ID of the Wasm code that was uploaded before */
+    readonly code_id: string;
+    /** Human-readable label for this contract */
+    readonly label: string;
+    /** Instantiate message as JavaScript object */
+    readonly msg: any;
+    readonly funds: readonly Coin[];
+    /** Bech32-encoded admin address */
+    readonly admin?: string;
+    /** Arbitrary Base64-encoded value provided by the sender */
+    readonly salt: string;
+    /** Whether or not to include the msg value into the hash for the address */
+    readonly fix_msg: boolean;
   };
 }
 
@@ -169,6 +196,47 @@ export function createWasmAminoConverters(): AminoConverters {
         msg: toUtf8(JSON.stringify(msg)),
         funds: [...funds],
         admin: admin ?? "",
+      }),
+    },
+    "/cosmwasm.wasm.v1.MsgInstantiateContract2": {
+      aminoType: "wasm/MsgInstantiateContract2",
+      toAmino: ({
+        sender,
+        codeId,
+        label,
+        msg,
+        funds,
+        admin,
+        salt,
+        fixMsg,
+      }: MsgInstantiateContract2): AminoMsgInstantiateContract2["value"] => ({
+        sender: sender,
+        code_id: codeId.toString(),
+        label: label,
+        msg: JSON.parse(fromUtf8(msg)),
+        funds: funds,
+        admin: admin || undefined,
+        salt: toBase64(salt),
+        fix_msg: fixMsg,
+      }),
+      fromAmino: ({
+        sender,
+        code_id,
+        label,
+        msg,
+        funds,
+        admin,
+        salt,
+        fix_msg,
+      }: AminoMsgInstantiateContract2["value"]): MsgInstantiateContract2 => ({
+        sender: sender,
+        codeId: Long.fromString(code_id),
+        label: label,
+        msg: toUtf8(JSON.stringify(msg)),
+        funds: [...funds],
+        admin: admin ?? "",
+        salt: fromBase64(salt),
+        fixMsg: fix_msg,
       }),
     },
     "/cosmwasm.wasm.v1.MsgUpdateAdmin": {


### PR DESCRIPTION
This adds the Amino converter for `MsgInstantiateContract2` so that the wasm module can be fully utilized by Amino clients.