### PR TITLE
fix(tendermint-rpc): add earliest block to sync info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- @cosmjs/tendermint-rpc: Add missing `earliest_*` fields to `SyncInfo` record
+  returned from the `/status` RPC endpoint ([#1448]).
+
 ## [0.31.0] - 2023-06-22
 
 ### Fixed

--- a/packages/tendermint-rpc/src/tendermint34/adaptor/responses.ts
+++ b/packages/tendermint-rpc/src/tendermint34/adaptor/responses.ts
@@ -620,6 +620,12 @@ function decodeNodeInfo(data: RpcNodeInfo): responses.NodeInfo {
 
 interface RpcSyncInfo {
   /** hex encoded */
+  readonly earliest_app_hash: string;
+  /** hex encoded */
+  readonly earliest_block_hash: string;
+  readonly earliest_block_height: string;
+  readonly earliest_block_time: string;
+  /** hex encoded */
   readonly latest_block_hash: string;
   /** hex encoded */
   readonly latest_app_hash: string;
@@ -629,7 +635,18 @@ interface RpcSyncInfo {
 }
 
 function decodeSyncInfo(data: RpcSyncInfo): responses.SyncInfo {
+  const earliestBlockHeight = data.earliest_block_height
+    ? apiToSmallInt(data.earliest_block_height)
+    : undefined;
+  const earliestBlockTime = data.earliest_block_time
+    ? fromRfc3339WithNanoseconds(data.earliest_block_time)
+    : undefined;
+
   return {
+    earliestAppHash: data.earliest_app_hash ? fromHex(data.earliest_app_hash) : undefined,
+    earliestBlockHash: data.earliest_block_hash ? fromHex(data.earliest_block_hash) : undefined,
+    earliestBlockHeight: earliestBlockHeight || undefined,
+    earliestBlockTime: earliestBlockTime?.getTime() ? earliestBlockTime : undefined,
     latestBlockHash: fromHex(assertNotEmpty(data.latest_block_hash)),
     latestAppHash: fromHex(assertNotEmpty(data.latest_app_hash)),
     latestBlockTime: fromRfc3339WithNanoseconds(assertNotEmpty(data.latest_block_time)),

--- a/packages/tendermint-rpc/src/tendermint34/responses.ts
+++ b/packages/tendermint-rpc/src/tendermint34/responses.ts
@@ -340,6 +340,10 @@ export interface NodeInfo {
 }
 
 export interface SyncInfo {
+  readonly earliestAppHash?: Uint8Array;
+  readonly earliestBlockHash?: Uint8Array;
+  readonly earliestBlockHeight?: number;
+  readonly earliestBlockTime?: ReadonlyDate;
   readonly latestBlockHash: Uint8Array;
   readonly latestAppHash: Uint8Array;
   readonly latestBlockHeight: number;

--- a/packages/tendermint-rpc/src/tendermint34/tendermint34client.spec.ts
+++ b/packages/tendermint-rpc/src/tendermint34/tendermint34client.spec.ts
@@ -218,6 +218,17 @@ function defaultTestSuite(rpcFactory: () => RpcClient, expected: ExpectedValues)
       // sync info
       expect(status.syncInfo.catchingUp).toEqual(false);
       expect(status.syncInfo.latestBlockHeight).toBeGreaterThanOrEqual(1);
+      expect(status.syncInfo.latestBlockTime).toBeInstanceOf(Date);
+      if (status.syncInfo.earliestBlockHeight) {
+        expect(status.syncInfo.earliestBlockHeight).toBeGreaterThanOrEqual(1);
+        expect(status.syncInfo.earliestBlockHeight).toBeLessThanOrEqual(status.syncInfo.latestBlockHeight);
+      }
+      if (status.syncInfo.earliestBlockTime) {
+        expect(status.syncInfo.earliestBlockTime).toBeInstanceOf(Date);
+        expect(status.syncInfo.earliestBlockTime.getTime()).toBeLessThanOrEqual(
+          status.syncInfo.latestBlockTime.getTime(),
+        );
+      }
 
       // validator info
       expect(status.validatorInfo.pubkey).toBeTruthy();

--- a/packages/tendermint-rpc/src/tendermint37/adaptor/responses.ts
+++ b/packages/tendermint-rpc/src/tendermint37/adaptor/responses.ts
@@ -621,6 +621,12 @@ function decodeNodeInfo(data: RpcNodeInfo): responses.NodeInfo {
 
 interface RpcSyncInfo {
   /** hex encoded */
+  readonly earliest_app_hash: string;
+  /** hex encoded */
+  readonly earliest_block_hash: string;
+  readonly earliest_block_height: string;
+  readonly earliest_block_time: string;
+  /** hex encoded */
   readonly latest_block_hash: string;
   /** hex encoded */
   readonly latest_app_hash: string;
@@ -630,7 +636,18 @@ interface RpcSyncInfo {
 }
 
 function decodeSyncInfo(data: RpcSyncInfo): responses.SyncInfo {
+  const earliestBlockHeight = data.earliest_block_height
+    ? apiToSmallInt(data.earliest_block_height)
+    : undefined;
+  const earliestBlockTime = data.earliest_block_time
+    ? fromRfc3339WithNanoseconds(data.earliest_block_time)
+    : undefined;
+
   return {
+    earliestAppHash: data.earliest_app_hash ? fromHex(data.earliest_app_hash) : undefined,
+    earliestBlockHash: data.earliest_block_hash ? fromHex(data.earliest_block_hash) : undefined,
+    earliestBlockHeight: earliestBlockHeight || undefined,
+    earliestBlockTime: earliestBlockTime?.getTime() ? earliestBlockTime : undefined,
     latestBlockHash: fromHex(assertNotEmpty(data.latest_block_hash)),
     latestAppHash: fromHex(assertNotEmpty(data.latest_app_hash)),
     latestBlockTime: fromRfc3339WithNanoseconds(assertNotEmpty(data.latest_block_time)),

--- a/packages/tendermint-rpc/src/tendermint37/responses.ts
+++ b/packages/tendermint-rpc/src/tendermint37/responses.ts
@@ -345,6 +345,10 @@ export interface NodeInfo {
 }
 
 export interface SyncInfo {
+  readonly earliestAppHash?: Uint8Array;
+  readonly earliestBlockHash?: Uint8Array;
+  readonly earliestBlockHeight?: number;
+  readonly earliestBlockTime?: ReadonlyDate;
   readonly latestBlockHash: Uint8Array;
   readonly latestAppHash: Uint8Array;
   readonly latestBlockHeight: number;

--- a/packages/tendermint-rpc/src/tendermint37/tendermint37client.spec.ts
+++ b/packages/tendermint-rpc/src/tendermint37/tendermint37client.spec.ts
@@ -218,6 +218,17 @@ function defaultTestSuite(rpcFactory: () => RpcClient, expected: ExpectedValues)
       // sync info
       expect(status.syncInfo.catchingUp).toEqual(false);
       expect(status.syncInfo.latestBlockHeight).toBeGreaterThanOrEqual(1);
+      expect(status.syncInfo.latestBlockTime).toBeInstanceOf(Date);
+      if (status.syncInfo.earliestBlockHeight) {
+        expect(status.syncInfo.earliestBlockHeight).toBeGreaterThanOrEqual(1);
+        expect(status.syncInfo.earliestBlockHeight).toBeLessThanOrEqual(status.syncInfo.latestBlockHeight);
+      }
+      if (status.syncInfo.earliestBlockTime) {
+        expect(status.syncInfo.earliestBlockTime).toBeInstanceOf(Date);
+        expect(status.syncInfo.earliestBlockTime.getTime()).toBeLessThanOrEqual(
+          status.syncInfo.latestBlockTime.getTime(),
+        );
+      }
 
       // validator info
       expect(status.validatorInfo.pubkey).toBeTruthy();


### PR DESCRIPTION
This should fix issue #1448. Those fields are returned from `/status` endpoint but I haven't tested this code. I'm open to any suggestions how I can test it easily.