### PR TITLE
Add pagination option to bank query

### DIFF
--- a/packages/stargate/src/modules/bank/queries.ts
+++ b/packages/stargate/src/modules/bank/queries.ts
@@ -8,13 +8,14 @@ import {
   QueryTotalSupplyResponse,
 } from "cosmjs-types/cosmos/bank/v1beta1/query";
 import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
+import type { PageRequest } from "cosmjs-types/helpers";
 
 import { createPagination, createProtobufRpcClient, QueryClient } from "../../queryclient";
 
 export interface BankExtension {
   readonly bank: {
     readonly balance: (address: string, denom: string) => Promise<Coin>;
-    readonly allBalances: (address: string) => Promise<Coin[]>;
+    readonly allBalances: (address: string, pagination?: PageRequest) => Promise<Coin[]>;
     readonly totalSupply: (paginationKey?: Uint8Array) => Promise<QueryTotalSupplyResponse>;
     readonly supplyOf: (denom: string) => Promise<Coin>;
     readonly denomMetadata: (denom: string) => Promise<Metadata>;
@@ -35,9 +36,9 @@ export function setupBankExtension(base: QueryClient): BankExtension {
         assert(balance);
         return balance;
       },
-      allBalances: async (address: string) => {
+      allBalances: async (address: string, pagination?: PageRequest) => {
         const { balances } = await queryService.AllBalances(
-          QueryAllBalancesRequest.fromPartial({ address: address }),
+          QueryAllBalancesRequest.fromPartial({ address: address, pagination: pagination }),
         );
         return balances;
       },


### PR DESCRIPTION
We're running into cases on Kujira where `allBalances` needs to be paginated to retrieve all of the balances. Exposing this to make it easier for us to do so.