### PR TITLE
Update validation of GasPrice.fromString to allow using ibc denoms as gas denom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to
 
 [#1516]: https://github.com/cosmos/cosmjs/pull/1516
 
+### Changed
+
+- @cosmjs/stargate: Update validation of GasPrice.fromString to allow using ibc denoms as gas denom ([#1522])
+
+[#1522]: https://github.com/cosmos/cosmjs/pull/1522
+
 ## [0.32.0] - 2023-11-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- @cosmjs/stargate: Update validation of GasPrice.fromString to allow using ibc denoms as gas denom ([#1522])
+
+[#1522]: https://github.com/cosmos/cosmjs/pull/1522
+
 ## [0.32.1] - 2023-12-04
 
 ### Fixed
@@ -16,12 +22,6 @@ and this project adheres to
   that `time.Time` dates are parsed correctly. ([#1516])
 
 [#1516]: https://github.com/cosmos/cosmjs/pull/1516
-
-### Changed
-
-- @cosmjs/stargate: Update validation of GasPrice.fromString to allow using ibc denoms as gas denom ([#1522])
-
-[#1522]: https://github.com/cosmos/cosmjs/pull/1522
 
 ## [0.32.0] - 2023-11-23
 

--- a/packages/stargate/src/fee.spec.ts
+++ b/packages/stargate/src/fee.spec.ts
@@ -51,16 +51,16 @@ describe("GasPrice", () => {
       expect(() => GasPrice.fromString("234")).toThrowError(/Invalid gas price string/i);
       expect(() => GasPrice.fromString("-234tkn")).toThrowError(/Invalid gas price string/i);
       // Checks details of <denom>
-      expect(() => GasPrice.fromString("234t")).toThrowError(/Invalid gas price string/i);
-      expect(() => GasPrice.fromString("234tt")).toThrowError(/Invalid gas price string/i);
+      expect(() => GasPrice.fromString("234t")).toThrowError(/denom must be between 3 and 128 characters/i);
+      expect(() => GasPrice.fromString("234tt")).toThrowError(/denom must be between 3 and 128 characters/i);
       expect(() =>
         GasPrice.fromString(
           "234ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt",
         ),
-      ).toThrowError(/Invalid gas price string/i);
+      ).toThrowError(/denom must be between 3 and 128 characters/i);
       // Checks details of <amount>
-      expect(() => GasPrice.fromString("3.utkn")).toThrowError(/Invalid gas price string/i);
-      expect(() => GasPrice.fromString("..utkn")).toThrowError(/Invalid gas price string/i);
+      expect(() => GasPrice.fromString("3.utkn")).toThrowError(/Fractional part missing/i);
+      expect(() => GasPrice.fromString("..utkn")).toThrowError(/More than one separator found/i);
     });
   });
 

--- a/packages/stargate/src/fee.spec.ts
+++ b/packages/stargate/src/fee.spec.ts
@@ -30,11 +30,10 @@ describe("GasPrice", () => {
         "0.14ucoin2": { amount: "0.14", denom: "ucoin2" },
         // eslint-disable-next-line @typescript-eslint/naming-convention
         "0.14FOOBAR": { amount: "0.14", denom: "FOOBAR" },
-        "0.01ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2":
-          {
-            amount: "0.01",
-            denom: "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-          },
+        "0.01ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2": {
+          amount: "0.01",
+          denom: "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+        },
       };
       for (const [input, expected] of Object.entries(inputs)) {
         const gasPrice = GasPrice.fromString(input);

--- a/packages/stargate/src/fee.spec.ts
+++ b/packages/stargate/src/fee.spec.ts
@@ -30,6 +30,11 @@ describe("GasPrice", () => {
         "0.14ucoin2": { amount: "0.14", denom: "ucoin2" },
         // eslint-disable-next-line @typescript-eslint/naming-convention
         "0.14FOOBAR": { amount: "0.14", denom: "FOOBAR" },
+        "0.01ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2":
+          {
+            amount: "0.01",
+            denom: "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+          },
       };
       for (const [input, expected] of Object.entries(inputs)) {
         const gasPrice = GasPrice.fromString(input);
@@ -46,16 +51,16 @@ describe("GasPrice", () => {
       expect(() => GasPrice.fromString("234")).toThrowError(/Invalid gas price string/i);
       expect(() => GasPrice.fromString("-234tkn")).toThrowError(/Invalid gas price string/i);
       // Checks details of <denom>
-      expect(() => GasPrice.fromString("234t")).toThrowError(/denom must be between 3 and 128 characters/i);
-      expect(() => GasPrice.fromString("234tt")).toThrowError(/denom must be between 3 and 128 characters/i);
+      expect(() => GasPrice.fromString("234t")).toThrowError(/Invalid gas price string/i);
+      expect(() => GasPrice.fromString("234tt")).toThrowError(/Invalid gas price string/i);
       expect(() =>
         GasPrice.fromString(
           "234ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt",
         ),
-      ).toThrowError(/denom must be between 3 and 128 characters/i);
+      ).toThrowError(/Invalid gas price string/i);
       // Checks details of <amount>
-      expect(() => GasPrice.fromString("3.utkn")).toThrowError(/Fractional part missing/i);
-      expect(() => GasPrice.fromString("..utkn")).toThrowError(/More than one separator found/i);
+      expect(() => GasPrice.fromString("3.utkn")).toThrowError(/Invalid gas price string/i);
+      expect(() => GasPrice.fromString("..utkn")).toThrowError(/Invalid gas price string/i);
     });
   });
 

--- a/packages/stargate/src/fee.ts
+++ b/packages/stargate/src/fee.ts
@@ -37,7 +37,7 @@ export class GasPrice {
    */
   public static fromString(gasPrice: string): GasPrice {
     // Use Decimal.fromUserInput and checkDenom for detailed checks and helpful error messages
-    const matchResult = gasPrice.match(/^([0-9.]+)([a-zA-Z][a-zA-Z0-9/:._-]*)$/i);
+    const matchResult = gasPrice.match(/^([0-9.]+)([a-zA-Z][a-zA-Z0-9/:._-]*)$/);
     if (!matchResult) {
       throw new Error("Invalid gas price string");
     }

--- a/packages/stargate/src/fee.ts
+++ b/packages/stargate/src/fee.ts
@@ -3,18 +3,6 @@ import { Decimal, Uint53 } from "@cosmjs/math";
 import { coins } from "@cosmjs/proto-signing";
 
 /**
- * Denom checker for the Cosmos SDK 0.42 denom pattern
- * (https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/types/coin.go#L599-L601).
- *
- * This is like a regexp but with helpful error messages.
- */
-function checkDenom(denom: string): void {
-  if (denom.length < 3 || denom.length > 128) {
-    throw new Error("Denom must be between 3 and 128 characters");
-  }
-}
-
-/**
  * A gas price, i.e. the price of a single unit of gas. This is typically a fraction of
  * the smallest fee token unit, such as 0.012utoken.
  */
@@ -37,12 +25,11 @@ export class GasPrice {
    */
   public static fromString(gasPrice: string): GasPrice {
     // Use Decimal.fromUserInput and checkDenom for detailed checks and helpful error messages
-    const matchResult = gasPrice.match(/^([0-9.]+)([a-z][a-z0-9]*)$/i);
+    const matchResult = gasPrice.match(/^(\d+(?:\.\d+)?|\.\d+)([a-zA-Z][a-zA-Z0-9/:._-]{2,127})$/i);
     if (!matchResult) {
       throw new Error("Invalid gas price string");
     }
     const [_, amount, denom] = matchResult;
-    checkDenom(denom);
     const fractionalDigits = 18;
     const decimalAmount = Decimal.fromUserInput(amount, fractionalDigits);
     return new GasPrice(decimalAmount, denom);

--- a/packages/stargate/src/fee.ts
+++ b/packages/stargate/src/fee.ts
@@ -3,6 +3,18 @@ import { Decimal, Uint53 } from "@cosmjs/math";
 import { coins } from "@cosmjs/proto-signing";
 
 /**
+ * Denom checker for the Cosmos SDK 0.42 denom pattern
+ * (https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/types/coin.go#L599-L601).
+ *
+ * This is like a regexp but with helpful error messages.
+ */
+function checkDenom(denom: string): void {
+  if (denom.length < 3 || denom.length > 128) {
+    throw new Error("Denom must be between 3 and 128 characters");
+  }
+}
+
+/**
  * A gas price, i.e. the price of a single unit of gas. This is typically a fraction of
  * the smallest fee token unit, such as 0.012utoken.
  */
@@ -25,11 +37,12 @@ export class GasPrice {
    */
   public static fromString(gasPrice: string): GasPrice {
     // Use Decimal.fromUserInput and checkDenom for detailed checks and helpful error messages
-    const matchResult = gasPrice.match(/^(\d+(?:\.\d+)?|\.\d+)([a-zA-Z][a-zA-Z0-9/:._-]{2,127})$/i);
+    const matchResult = gasPrice.match(/^([0-9.]+)([a-zA-Z][a-zA-Z0-9/:._-]*)$/i);
     if (!matchResult) {
       throw new Error("Invalid gas price string");
     }
     const [_, amount, denom] = matchResult;
+    checkDenom(denom);
     const fractionalDigits = 18;
     const decimalAmount = Decimal.fromUserInput(amount, fractionalDigits);
     return new GasPrice(decimalAmount, denom);


### PR DESCRIPTION
Currently the `GasPrice.fromString` method claims that the denom validation matches the "[Cosmos SDK 0.42 pattern](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/types/coin.go#L599-L601)"; But the regex being used for validation is not the same as the one used in the sdk. Because of that, creating a gas price using IBC denoms which contain "/" is not possible and throws an error. This PR intends to update the validation regex to fix this issue.