### PR TITLE
fix(amino/coin): ibc denoms should be parsable

### DIFF
--- a/packages/amino/src/coins.ts
+++ b/packages/amino/src/coins.ts
@@ -60,7 +60,7 @@ export function parseCoins(input: string): Coin[] {
     .split(",")
     .filter(Boolean)
     .map((part) => {
-      const match = part.match(/^([0-9]+)([a-zA-Z]+)/);
+      const match = part.match(/^(\d+(?:\.\d+)?|\.\d+)([a-zA-Z][a-zA-Z0-9/:._-]{2,127})$/i);
       if (!match) throw new Error("Got an invalid coin string");
       return {
         amount: match[1].replace(/^0+/, "") || "0",


### PR DESCRIPTION
Applied same regex as https://github.com/cosmos/cosmjs/commit/643bf25a8a5449a00ad8c11bce01b5da6db4f6f4#diff-9136eafb27b821610a184d11b99ace152206c81924606263f9443a75ff2865aeR28.

ps: the commit specifies that it has been merged into main and yet I don't see any changes in version v0.32.2 either via npm or this github repository.