### PR TITLE
Feat: Add authz amino converter

### DIFF
--- a/packages/stargate/src/modules/authz/aminomessages.spec.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.spec.ts
@@ -19,13 +19,14 @@ describe("Authz Amino Converters", () => {
             authorization: {
               type: "cosmos-sdk/SendAuthorization",
               value: {
-                spendLimit: [{ denom: "ustake", amount: "1000" }],
+                spendLimit: [{ denom: "ustake", amount: "1000000" }],
+                allowList: [],
               },
             },
-            expiration: Timestamp.fromPartial({
-              seconds: BigInt(1596300000),
-              nanos: 0,
-            }),
+            // expiration: Timestamp.fromPartial({
+            //   seconds: BigInt(1596300000),
+            //   nanos: 0,
+            // }),
           },
         },
       };
@@ -38,16 +39,20 @@ describe("Authz Amino Converters", () => {
           authorization: {
             typeUrl: "/cosmos.bank.v1beta1.SendAuthorization",
             value: SendAuthorization.encode({
-              spendLimit: [{ denom: "ustake", amount: "1000" }],
+              spendLimit: [{ denom: "ustake", amount: "1000000" }],
               allowList: [],
             }).finish(),
           },
-          expiration: {
-            seconds: BigInt(1596300000),
-            nanos: 0,
-          },
+          // expiration: {
+          //   seconds: BigInt(1596300000),
+          //   nanos: 0,
+          // },
         },
       };
+      console.log(msgGrant.value.grant.authorization);
+
+      // console.log(expectedValue.grant.authorization?.value);
+
       expect(msgGrant).toEqual({
         typeUrl: "/cosmos.authz.v1beta1.MsgGrant",
         value: expectedValue,

--- a/packages/stargate/src/modules/authz/aminomessages.spec.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.spec.ts
@@ -1,0 +1,63 @@
+import { MsgExec, MsgGrant, MsgRevoke } from "cosmjs-types/cosmos/authz/v1beta1/tx";
+import { SendAuthorization } from "cosmjs-types/cosmos/bank/v1beta1/authz";
+import { AminoConverters } from "src/aminotypes";
+
+import { AminoMsgGrant, createAuthzAminoConverters } from "./aminomessages";
+import { Timestamp } from "cosmjs-types/google/protobuf/timestamp";
+import { AminoTypes } from "../../aminotypes";
+
+describe("Authz Amino Converters", () => {
+  describe("fromAmino", () => {
+    it("work with MsgGrant", () => {
+      // Define a sample AminoMsgGrant object
+      const msg: AminoMsgGrant = {
+        type: "cosmos-sdk/MsgGrant",
+        value: {
+          granter: "cosmos1p7v0km9ydt0y9nszlesjy8elzqc4n2v0w4xh2p",
+          grantee: "cosmos10dyr9899g6t0pelew4nvf4j5c3jcgv0r73qga5",
+          grant: {
+            authorization: {
+              type: "cosmos-sdk/SendAuthorization",
+              value: {
+                spendLimit: [{ denom: "ustake", amount: "1000" }],
+              },
+            },
+            expiration: Timestamp.fromPartial({
+              seconds: BigInt(1596300000),
+              nanos: 0,
+            }),
+          },
+        },
+      };
+
+      const msgGrant = new AminoTypes(createAuthzAminoConverters()).fromAmino(msg);
+      const expectedValue: MsgGrant = {
+        granter: "cosmos1p7v0km9ydt0y9nszlesjy8elzqc4n2v0w4xh2p",
+        grantee: "cosmos10dyr9899g6t0pelew4nvf4j5c3jcgv0r73qga5",
+        grant: {
+          authorization: {
+            typeUrl: "/cosmos.bank.v1beta1.SendAuthorization",
+            value: SendAuthorization.encode({
+              spendLimit: [{ denom: "ustake", amount: "1000" }],
+              allowList: [],
+            }).finish(),
+          },
+          expiration: {
+            seconds: BigInt(1596300000),
+            nanos: 0,
+          },
+        },
+      };
+      expect(msgGrant).toEqual({
+        typeUrl: "/cosmos.authz.v1beta1.MsgGrant",
+        value: expectedValue,
+      });
+    });
+
+    // it("toAmino", () => {});
+  });
+
+  // describe("MsgExec", () => {});
+
+  // describe("MsgRevoke", () => {});
+});

--- a/packages/stargate/src/modules/authz/aminomessages.spec.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.spec.ts
@@ -1,10 +1,9 @@
 import { MsgExec, MsgGrant, MsgRevoke } from "cosmjs-types/cosmos/authz/v1beta1/tx";
 import { SendAuthorization } from "cosmjs-types/cosmos/bank/v1beta1/authz";
-import { AminoConverters } from "src/aminotypes";
 
-import { AminoMsgGrant, createAuthzAminoConverters } from "./aminomessages";
-import { Timestamp } from "cosmjs-types/google/protobuf/timestamp";
+import { AminoMsgExec, AminoMsgGrant, AminoMsgRevoke, createAuthzAminoConverters } from "./aminomessages";
 import { AminoTypes } from "../../aminotypes";
+import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
 
 describe("Authz Amino Converters", () => {
   describe("fromAmino", () => {
@@ -53,10 +52,70 @@ describe("Authz Amino Converters", () => {
       });
     });
 
-    // it("toAmino", () => {});
+    it("work with MsgExec", () => {
+      // Define a sample AminoMsgExec object
+      const msg: AminoMsgExec = {
+        type: "cosmos-sdk/MsgExec",
+        value: {
+          grantee: "cosmos10dyr9899g6t0pelew4nvf4j5c3jcgv0r73qga5",
+          msgs: [
+            {
+              typeUrl: "cosmos-sdk/MsgSend",
+              value: MsgSend.encode({
+                fromAddress: "cosmos1p7v0km9ydt0y9nszlesjy8elzqc4n2v0w4xh2p",
+                toAddress: "cosmos1p7v0km9ydt0y9nszlesjy8elzqc4n2v0w4xh2p",
+                amount: [{ denom: "ustake", amount: "1000000" }],
+              }).finish(),
+            },
+          ],
+        },
+      };
+
+      const msgExec = new AminoTypes(createAuthzAminoConverters()).fromAmino(msg);
+      const expectedValue: MsgExec = {
+        grantee: "cosmos10dyr9899g6t0pelew4nvf4j5c3jcgv0r73qga5",
+        msgs: [
+          {
+            typeUrl: "cosmos-sdk/MsgSend",
+            value: MsgSend.encode({
+              fromAddress: "cosmos1p7v0km9ydt0y9nszlesjy8elzqc4n2v0w4xh2p",
+              toAddress: "cosmos1p7v0km9ydt0y9nszlesjy8elzqc4n2v0w4xh2p",
+              amount: [{ denom: "ustake", amount: "1000000" }],
+            }).finish(),
+          },
+        ],
+      };
+
+      expect(msgExec).toEqual({
+        typeUrl: "/cosmos.authz.v1beta1.MsgExec",
+        value: expectedValue,
+      });
+    });
+
+    it("work with MsgRevoke", () => {
+      // Define a sample AminoMsgExec object
+      const msg: AminoMsgRevoke = {
+        type: "cosmos-sdk/MsgRevoke",
+        value: {
+          granter: "cosmos1p7v0km9ydt0y9nszlesjy8elzqc4n2v0w4xh2p",
+          grantee: "cosmos10dyr9899g6t0pelew4nvf4j5c3jcgv0r73qga5",
+          msg_type_url: "cosmos-sdk/MsgSend",
+        },
+      };
+
+      const msgRevoke = new AminoTypes(createAuthzAminoConverters()).fromAmino(msg);
+      const expectedValue: MsgRevoke = {
+        granter: "cosmos1p7v0km9ydt0y9nszlesjy8elzqc4n2v0w4xh2p",
+        grantee: "cosmos10dyr9899g6t0pelew4nvf4j5c3jcgv0r73qga5",
+        msgTypeUrl: "cosmos-sdk/MsgSend",
+      };
+
+      expect(msgRevoke).toEqual({
+        typeUrl: "/cosmos.authz.v1beta1.MsgRevoke",
+        value: expectedValue,
+      });
+    });
   });
 
-  // describe("MsgExec", () => {});
-
-  // describe("MsgRevoke", () => {});
+  // describe("fromAmino", () => {});
 });

--- a/packages/stargate/src/modules/authz/aminomessages.spec.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.spec.ts
@@ -19,14 +19,11 @@ describe("Authz Amino Converters", () => {
             authorization: {
               type: "cosmos-sdk/SendAuthorization",
               value: {
-                spendLimit: [{ denom: "ustake", amount: "1000000" }],
-                allowList: [],
+                spend_limit: [{ denom: "ustake", amount: "1000000" }],
+                allow_list: ["cosmos147auavf4tvghskslq2w65de0nh5dqdmljxc7kh"],
               },
             },
-            // expiration: Timestamp.fromPartial({
-            //   seconds: BigInt(1596300000),
-            //   nanos: 0,
-            // }),
+            expiration: "Mon Jan 19 1970 19:25:00 GMT+0800 (Indochina Time)",
           },
         },
       };
@@ -40,18 +37,15 @@ describe("Authz Amino Converters", () => {
             typeUrl: "/cosmos.bank.v1beta1.SendAuthorization",
             value: SendAuthorization.encode({
               spendLimit: [{ denom: "ustake", amount: "1000000" }],
-              allowList: [],
+              allowList: ["cosmos147auavf4tvghskslq2w65de0nh5dqdmljxc7kh"],
             }).finish(),
           },
-          // expiration: {
-          //   seconds: BigInt(1596300000),
-          //   nanos: 0,
-          // },
+          expiration: {
+            seconds: BigInt(1596300),
+            nanos: 0,
+          },
         },
       };
-      console.log(msgGrant.value.grant.authorization);
-
-      // console.log(expectedValue.grant.authorization?.value);
 
       expect(msgGrant).toEqual({
         typeUrl: "/cosmos.authz.v1beta1.MsgGrant",

--- a/packages/stargate/src/modules/authz/aminomessages.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.ts
@@ -5,7 +5,7 @@ import { SendAuthorization } from "cosmjs-types/cosmos/bank/v1beta1/authz";
 import { StakeAuthorization } from "cosmjs-types/cosmos/staking/v1beta1/authz";
 import { Any } from "cosmjs-types/google/protobuf/any";
 import { Timestamp } from "cosmjs-types/google/protobuf/timestamp";
-import { AminoConverters } from "src/aminotypes";
+import { AminoConverters } from "../../aminotypes";
 
 interface AminoGrant {
   authorization?: any;

--- a/packages/stargate/src/modules/authz/aminomessages.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.ts
@@ -1,12 +1,11 @@
-import { AminoConverters } from "../../aminotypes";
-import { AminoMsg, Coin } from "@cosmjs/amino";
-import { MsgGrant, MsgExec, MsgRevoke } from "cosmjs-types/cosmos/authz/v1beta1/tx";
-import { Any } from "../../../google/protobuf/any";
-import { Timestamp } from "../../../google/protobuf/timestamp";
-import { GenericAuthorization, AuthorizationType } from 'cosmjs-types/cosmos/authz/v1beta1/authz';
-import { SendAuthorization } from 'cosmjs-types/cosmos/bank/v1beta1/authz';
-import { StakeAuthorization } from 'cosmjs-types/cosmos/staking/v1beta1/authz';
-
+import { AminoMsg } from "@cosmjs/amino";
+import { GenericAuthorization } from "cosmjs-types/cosmos/authz/v1beta1/authz";
+import { MsgExec, MsgGrant, MsgRevoke } from "cosmjs-types/cosmos/authz/v1beta1/tx";
+import { SendAuthorization } from "cosmjs-types/cosmos/bank/v1beta1/authz";
+import { StakeAuthorization } from "cosmjs-types/cosmos/staking/v1beta1/authz";
+import { Any } from "cosmjs-types/google/protobuf/any";
+import { Timestamp } from "cosmjs-types/google/protobuf/timestamp";
+import { AminoConverters } from "src/aminotypes";
 
 interface Grant {
   authorization?: any;
@@ -29,11 +28,9 @@ export interface AminoMsgExec extends AminoMsg {
   readonly value: {
     /** Bech32 account address */
     readonly grantee: string;
-
     readonly msgs: readonly Any[];
   };
 }
-
 
 export interface AminoMsgRevoke extends AminoMsg {
   readonly type: "cosmos-sdk/MsgRevoke";
@@ -42,10 +39,10 @@ export interface AminoMsgRevoke extends AminoMsg {
     readonly granter: string;
     /** Bech32 account address */
     readonly grantee: string;
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     readonly msg_type_url: string;
   };
 }
-
 
 export function createAuthzAminoConverters(): AminoConverters {
   return {
@@ -57,63 +54,57 @@ export function createAuthzAminoConverters(): AminoConverters {
       aminoType: "cosmos-sdk/MsgGrant",
       toAmino: ({ granter, grantee, grant }: MsgGrant) => {
         if (!grant || !grant.authorization || grant.authorization.typeUrl === "") {
-          throw new Error(
-            `Unsupported grant type: '${grant?.authorization?.typeUrl}'`,
-          );
+          throw new Error(`Unsupported grant type: '${grant?.authorization?.typeUrl}'`);
         }
         let authorizationValue;
         switch (grant.authorization.typeUrl) {
-          case '/cosmos.authz.v1beta1.GenericAuthorization': {
-            const generic = GenericAuthorization.decode(
-              grant.authorization.value,
-            );
+          case "/cosmos.authz.v1beta1.GenericAuthorization": {
+            const generic = GenericAuthorization.decode(grant.authorization.value);
             authorizationValue = {
-              type: 'cosmos-sdk/GenericAuthorization',
+              type: "cosmos-sdk/GenericAuthorization",
               value: {
                 msg: generic.msg,
               },
             };
             break;
           }
-          case '/cosmos.bank.v1beta1.SendAuthorization': {
+          case "/cosmos.bank.v1beta1.SendAuthorization": {
             const spend = SendAuthorization.decode(grant.authorization.value);
             authorizationValue = {
-              type: 'cosmos-sdk/SendAuthorization',
+              type: "cosmos-sdk/SendAuthorization",
               value: {
                 spend_limit: spend.spendLimit,
               },
             };
             break;
           }
-          case '/cosmos.staking.v1beta1.StakeAuthorization': {
+          case "/cosmos.staking.v1beta1.StakeAuthorization": {
             const stakeAuthorization = StakeAuthorization.decode(grant.authorization.value);
-            if (stakeAuthorization?.allowList?.address.length === 0 && stakeAuthorization?.denyList?.address.length === 0) {
-              throw new Error(
-                'Allow list and deny list can`t be both empty'
-              );
-            }
 
-            if (stakeAuthorization?.allowList?.address.length > 0 && stakeAuthorization?.denyList?.address.length > 0) {
-              throw new Error(
-                'Can only set allow list or deny list at a time'
-              );
+            if (stakeAuthorization) {
+              const isAllowListEmpty = stakeAuthorization.allowList?.address.length === 0;
+              const isDenyListEmpty = stakeAuthorization.denyList?.address.length === 0;
+
+              if (isAllowListEmpty && isDenyListEmpty) {
+                throw new Error("Allow list and deny list can't be both empty");
+              } else if (!isAllowListEmpty && !isDenyListEmpty) {
+                throw new Error("Can only set allow list or deny list at a time");
+              }
             }
 
             authorizationValue = {
-              type: 'cosmos-sdk/StakeAuthorization',
+              type: "cosmos-sdk/StakeAuthorization",
               value: {
                 max_tokens: stakeAuthorization.maxTokens,
                 allow_list: stakeAuthorization.allowList,
                 deny_list: stakeAuthorization.denyList,
-                authorization_type: stakeAuthorization.authorizationType
+                authorization_type: stakeAuthorization.authorizationType,
               },
             };
             break;
           }
           default:
-            throw new Error(
-              `Unsupported grant type: '${grant.authorization.typeUrl}'`,
-            );
+            throw new Error(`Unsupported grant type: '${grant.authorization.typeUrl}'`);
         }
         const expiration = grant.expiration?.seconds;
         return {
@@ -122,59 +113,57 @@ export function createAuthzAminoConverters(): AminoConverters {
           grant: {
             authorization: authorizationValue,
             expiration: expiration
-              ? new Date(expiration.toNumber() * 1000).toISOString().replace(/\.000Z$/, 'Z')
+              ? new Date(Number(expiration) * 1000).toISOString().replace(/\.000Z$/, "Z")
               : undefined,
           },
         };
       },
-      fromAmino: ({ granter, grantee, grant }: {
-        granter: string; grantee: string; grant: any;
+      fromAmino: ({
+        granter,
+        grantee,
+        grant,
+      }: {
+        granter: string;
+        grantee: string;
+        grant: any;
       }): MsgGrant => {
         const authorizationType = grant?.authorization?.type;
         let authorizationValue;
         switch (authorizationType) {
-          case 'cosmos-sdk/GenericAuthorization': {
+          case "cosmos-sdk/GenericAuthorization": {
             authorizationValue = {
-              typeUrl: '/cosmos.authz.v1beta1.GenericAuthorization',
-              value: GenericAuthorization
-                .encode({ msg: grant.authorization.value.msg })
-                .finish(),
+              typeUrl: "/cosmos.authz.v1beta1.GenericAuthorization",
+              value: GenericAuthorization.encode({ msg: grant.authorization.value.msg }).finish(),
             };
             break;
           }
-          case 'cosmos-sdk/SendAuthorization': {
+          case "cosmos-sdk/SendAuthorization": {
             authorizationValue = {
-              typeUrl: '/cosmos.bank.v1beta1.SendAuthorization',
-              value: SendAuthorization
-                .encode(SendAuthorization
-                  .fromPartial({ spendLimit: grant.authorization.value.spend_limit }))
-                .finish(),
+              typeUrl: "/cosmos.bank.v1beta1.SendAuthorization",
+              value: SendAuthorization.encode(
+                SendAuthorization.fromPartial({ spendLimit: grant.authorization.value.spend_limit }),
+              ).finish(),
             };
             break;
           }
-          case 'cosmos-sdk/StakeAuthorization': {
+          case "cosmos-sdk/StakeAuthorization": {
             authorizationValue = {
-              typeUrl: '/cosmos.staking.v1beta1.StakeAuthorization',
-              value: StakeAuthorization
-                .encode(StakeAuthorization
-                  .fromPartial({
-                    maxTokens: grant.authorization.value.max_token,
-                    allowList: grant.authorization.value.allow_list,
-                    denyList: grant.authorization.value.deny_list,
-                    authorizationType: grant.authorization.value.authorization_type,
-                  }))
-                .finish(),
+              typeUrl: "/cosmos.staking.v1beta1.StakeAuthorization",
+              value: StakeAuthorization.encode(
+                StakeAuthorization.fromPartial({
+                  maxTokens: grant.authorization.value.max_token,
+                  allowList: grant.authorization.value.allow_list,
+                  denyList: grant.authorization.value.deny_list,
+                  authorizationType: grant.authorization.value.authorization_type,
+                }),
+              ).finish(),
             };
             break;
           }
           default:
-            throw new Error(
-              `Unsupported grant type: '${grant?.authorization?.type}'`,
-            );
+            throw new Error(`Unsupported grant type: '${grant?.authorization?.type}'`);
         }
-        const expiration = grant.expiration
-          ? Date.parse(grant.expiration)
-          : undefined;
+        const expiration = grant.expiration ? Date.parse(grant.expiration) : undefined;
         return MsgGrant.fromPartial({
           granter,
           grantee,
@@ -182,58 +171,56 @@ export function createAuthzAminoConverters(): AminoConverters {
             authorization: authorizationValue,
             expiration: expiration
               ? Timestamp.fromPartial({
-                seconds: expiration / 1000,
-                nanos: (expiration % 1000) * 1e6,
-              })
+                  seconds: BigInt(expiration / 1000),
+                  nanos: (expiration % 1000) * 1e6,
+                })
               : undefined,
           },
         });
       },
     },
     "/cosmos.authz.v1beta1.MsgExec": {
-      aminoType: 'cosmos-sdk/MsgExec',
+      aminoType: "cosmos-sdk/MsgExec",
       toAmino: ({ grantee, msgs }: MsgExec) => {
         if (msgs.length === 0) {
-          throw new Error(
-            'Messages list must not be empty',
-          );
+          throw new Error("Messages list must not be empty");
         }
         return MsgExec.fromPartial({
           grantee,
           msgs,
-        })
+        });
       },
-      /* eslint-disable camelcase */
-      fromAmino: ({ grantee, msgs }: {
-        grantee: string, msgs: Any[]
-      }): MsgExec => {
+      fromAmino: ({ grantee, msgs }: { grantee: string; msgs: Any[] }): MsgExec => {
         if (msgs.length === 0) {
-          throw new Error(
-            'Messages list must not be empty',
-          );
+          throw new Error("Messages list must not be empty");
         }
-        return MsgExec.fromPartial(
-          grantee,
-          msgs,
-        )
+        return MsgExec.fromPartial({ grantee, msgs });
       },
-      /* eslint-enable camelcase */
     },
     "/cosmos.authz.v1beta1.MsgRevoke": {
-      aminoType: 'cosmos-sdk/MsgRevoke',
+      aminoType: "cosmos-sdk/MsgRevoke",
       toAmino: ({ granter, grantee, msgTypeUrl }: MsgRevoke) => ({
         granter,
         grantee,
         msg_type_url: msgTypeUrl,
       }),
       /* eslint-disable camelcase */
-      fromAmino: ({ granter, grantee, msg_type_url }: {
-        granter: string, grantee: string, msg_type_url: string
-      }): MsgRevoke => MsgRevoke.fromPartial({
+      fromAmino: ({
         granter,
         grantee,
-        msgTypeUrl: msg_type_url,
-      }),
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        msg_type_url,
+      }: {
+        granter: string;
+        grantee: string;
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        msg_type_url: string;
+      }): MsgRevoke =>
+        MsgRevoke.fromPartial({
+          granter,
+          grantee,
+          msgTypeUrl: msg_type_url,
+        }),
       /* eslint-enable camelcase */
     },
   };

--- a/packages/stargate/src/modules/authz/aminomessages.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.ts
@@ -153,7 +153,7 @@ export function createAuthzAminoConverters(): AminoConverters {
           case 'cosmos-sdk/StakeAuthorization': {
             authorizationValue = {
               typeUrl: '/cosmos.staking.v1beta1.StakeAuthorization',
-              value: SendAuthorization
+              value: StakeAuthorization
                 .encode(StakeAuthorization
                   .fromPartial({
                     maxTokens: grant.authorization.value.max_token,

--- a/packages/stargate/src/modules/authz/aminomessages.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.ts
@@ -74,6 +74,7 @@ export function createAuthzAminoConverters(): AminoConverters {
               type: "cosmos-sdk/SendAuthorization",
               value: {
                 spend_limit: spend.spendLimit,
+                allow_list: spend.allowList,
               },
             };
             break;
@@ -141,7 +142,10 @@ export function createAuthzAminoConverters(): AminoConverters {
             authorizationValue = {
               typeUrl: "/cosmos.bank.v1beta1.SendAuthorization",
               value: SendAuthorization.encode(
-                SendAuthorization.fromPartial({ spendLimit: grant.authorization.value.spend_limit }),
+                SendAuthorization.fromPartial({
+                  spendLimit: grant.authorization.value.spend_limit,
+                  allowList: grant.authorization.value.allow_list,
+                }),
               ).finish(),
             };
             break;

--- a/packages/stargate/src/modules/authz/aminomessages.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.ts
@@ -7,9 +7,9 @@ import { Any } from "cosmjs-types/google/protobuf/any";
 import { Timestamp } from "cosmjs-types/google/protobuf/timestamp";
 import { AminoConverters } from "src/aminotypes";
 
-interface Grant {
+interface AminoGrant {
   authorization?: any;
-  expiration?: Timestamp;
+  expiration?: string;
 }
 
 export interface AminoMsgGrant extends AminoMsg {
@@ -19,7 +19,7 @@ export interface AminoMsgGrant extends AminoMsg {
     readonly granter: string;
     /** Bech32 account address */
     readonly grantee: string;
-    readonly grant: Grant;
+    readonly grant: AminoGrant;
   };
 }
 

--- a/packages/stargate/src/modules/authz/aminomessages.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.ts
@@ -1,4 +1,49 @@
 import { AminoConverters } from "../../aminotypes";
+import { AminoMsg, Coin } from "@cosmjs/amino";
+import { MsgGrant, MsgExec, MsgRevoke } from "cosmjs-types/cosmos/authz/v1beta1/tx";
+import { Any } from "../../../google/protobuf/any";
+import { GenericAuthorization, AuthorizationType } from 'cosmjs-types/cosmos/authz/v1beta1/authz';
+import { SendAuthorization } from 'cosmjs-types/cosmos/bank/v1beta1/authz';
+import { StakeAuthorization } from 'cosmjs-types/cosmos/staking/v1beta1/authz';
+
+interface Grant {
+  authorization?: any;
+  expiration?: Timestamp;
+}
+
+export interface AminoMsgGrant extends AminoMsg {
+  readonly type: "cosmos-sdk/MsgGrant";
+  readonly value: {
+    /** Bech32 account address */
+    readonly granter: string;
+    /** Bech32 account address */
+    readonly grantee: string;
+    readonly grant: Grant;
+  };
+}
+
+export interface AminoMsgExec extends AminoMsg {
+  readonly type: "cosmos-sdk/MsgExec";
+  readonly value: {
+    /** Bech32 account address */
+    readonly grantee: string;
+
+    readonly msgs: readonly Any[];
+  };
+}
+
+
+export interface AminoMsgRevoke extends AminoMsg {
+  readonly type: "cosmos-sdk/MsgRevoke";
+  readonly value: {
+    /** Bech32 account address */
+    readonly granter: string;
+    /** Bech32 account address */
+    readonly grantee: string;
+    readonly msg_type_url: string;
+  };
+}
+
 
 export function createAuthzAminoConverters(): AminoConverters {
   return {
@@ -6,8 +51,188 @@ export function createAuthzAminoConverters(): AminoConverters {
     // Now this can be implemented for 0.46+ chains, see
     // https://github.com/cosmos/cosmjs/issues/1092
     //
-    // "/cosmos.authz.v1beta1.MsgGrant": IMPLEMENT ME,
-    // "/cosmos.authz.v1beta1.MsgExec": IMPLEMENT ME,
-    // "/cosmos.authz.v1beta1.MsgRevoke": IMPLEMENT ME,
+    "/cosmos.authz.v1beta1.MsgGrant": {
+      aminoType: "cosmos-sdk/MsgGrant",
+      toAmino: ({ granter, grantee, grant }: MsgGrant) => {
+        if (!grant || !grant.authorization || grant.authorization.typeUrl === "") {
+          throw new Error(
+            `Unsupported grant type: '${grant?.authorization?.typeUrl}'`,
+          );
+        }
+        let authorizationValue;
+        switch (grant.authorization.typeUrl) {
+          case '/cosmos.authz.v1beta1.GenericAuthorization': {
+            const generic = GenericAuthorization.decode(
+              grant.authorization.value,
+            );
+            authorizationValue = {
+              type: 'cosmos-sdk/GenericAuthorization',
+              value: {
+                msg: generic.msg,
+              },
+            };
+            break;
+          }
+          case '/cosmos.bank.v1beta1.SendAuthorization': {
+            const spend = SendAuthorization.decode(grant.authorization.value);
+            authorizationValue = {
+              type: 'cosmos-sdk/SendAuthorization',
+              value: {
+                spend_limit: spend.spendLimit,
+              },
+            };
+            break;
+          }
+          case '/cosmos.staking.v1beta1.StakeAuthorization': {
+            const stakeAuthorization = StakeAuthorization.decode(grant.authorization.value);
+            if (stakeAuthorization?.allowList?.address.length === 0 && stakeAuthorization?.denyList?.address.length === 0) {
+              throw new Error(
+                'Allow list and deny list can`t be both empty'
+              );
+            }
+
+            if (stakeAuthorization?.allowList?.address.length > 0 && stakeAuthorization?.denyList?.address.length > 0) {
+              throw new Error(
+                'Can only set allow list or deny list at a time'
+              );
+            }
+
+            authorizationValue = {
+              type: 'cosmos-sdk/StakeAuthorization',
+              value: {
+                max_tokens: stakeAuthorization.maxTokens,
+                allow_list: stakeAuthorization.allowList,
+                deny_list: stakeAuthorization.denyList,
+                authorization_type: stakeAuthorization.authorizationType
+              },
+            };
+            break;
+          }
+          default:
+            throw new Error(
+              `Unsupported grant type: '${grant.authorization.typeUrl}'`,
+            );
+        }
+        const expiration = grant.expiration?.seconds;
+        return {
+          granter,
+          grantee,
+          grant: {
+            authorization: authorizationValue,
+            expiration: expiration
+              ? new Date(expiration.toNumber() * 1000).toISOString().replace(/\.000Z$/, 'Z')
+              : undefined,
+          },
+        };
+      },
+      fromAmino: ({ granter, grantee, grant }: {
+        granter: string; grantee: string; grant: any;
+      }): MsgGrant => {
+        const authorizationType = grant?.authorization?.type;
+        let authorizationValue;
+        switch (authorizationType) {
+          case 'cosmos-sdk/GenericAuthorization': {
+            authorizationValue = {
+              typeUrl: '/cosmos.authz.v1beta1.GenericAuthorization',
+              value: GenericAuthorization
+                .encode({ msg: grant.authorization.value.msg })
+                .finish(),
+            };
+            break;
+          }
+          case 'cosmos-sdk/SendAuthorization': {
+            authorizationValue = {
+              typeUrl: '/cosmos.bank.v1beta1.SendAuthorization',
+              value: SendAuthorization
+                .encode(SendAuthorization
+                  .fromPartial({ spendLimit: grant.authorization.value.spend_limit }))
+                .finish(),
+            };
+            break;
+          }
+          case 'cosmos-sdk/StakeAuthorization': {
+            authorizationValue = {
+              typeUrl: '/cosmos.staking.v1beta1.StakeAuthorization',
+              value: SendAuthorization
+                .encode(StakeAuthorization
+                  .fromPartial({
+                    maxTokens: grant.authorization.value.max_token,
+                    allowList: grant.authorization.value.allow_list,
+                    denyList: grant.authorization.value.deny_list,
+                    authorizationType: grant.authorization.value.authorization_type,
+                  }))
+                .finish(),
+            };
+            break;
+          }
+          default:
+            throw new Error(
+              `Unsupported grant type: '${grant?.authorization?.type}'`,
+            );
+        }
+        const expiration = grant.expiration
+          ? Date.parse(grant.expiration)
+          : undefined;
+        return MsgGrant.fromPartial({
+          granter,
+          grantee,
+          grant: {
+            authorization: authorizationValue,
+            expiration: expiration
+              ? Timestamp.fromPartial({
+                seconds: expiration / 1000,
+                nanos: (expiration % 1000) * 1e6,
+              })
+              : undefined,
+          },
+        });
+      },
+    },
+    "/cosmos.authz.v1beta1.MsgExec": {
+      aminoType: 'cosmos-sdk/MsgExec',
+      toAmino: ({ grantee, msgs }: MsgExec) => {
+        if (msgs.length === 0) {
+          throw new Error(
+            'Messages list must not be empty',
+          );
+        }
+        return MsgExec.fromPartial({
+          grantee,
+          msgs,
+        })
+      },
+      /* eslint-disable camelcase */
+      fromAmino: ({ grantee, msgs }: {
+        grantee: string, msgs: Any[]
+      }): MsgExec => {
+        if (msgs.length === 0) {
+          throw new Error(
+            'Messages list must not be empty',
+          );
+        }
+        return MsgExec.fromPartial(
+          grantee,
+          msgs,
+        )
+      },
+      /* eslint-enable camelcase */
+    },
+    "/cosmos.authz.v1beta1.MsgRevoke": {
+      aminoType: 'cosmos-sdk/MsgRevoke',
+      toAmino: ({ granter, grantee, msgTypeUrl }: MsgRevoke) => ({
+        granter,
+        grantee,
+        msg_type_url: msgTypeUrl,
+      }),
+      /* eslint-disable camelcase */
+      fromAmino: ({ granter, grantee, msg_type_url }: {
+        granter: string, grantee: string, msg_type_url: string
+      }): MsgRevoke => MsgRevoke.fromPartial({
+        granter,
+        grantee,
+        msgTypeUrl: msg_type_url,
+      }),
+      /* eslint-enable camelcase */
+    },
   };
 }

--- a/packages/stargate/src/modules/authz/aminomessages.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.ts
@@ -2,9 +2,11 @@ import { AminoConverters } from "../../aminotypes";
 import { AminoMsg, Coin } from "@cosmjs/amino";
 import { MsgGrant, MsgExec, MsgRevoke } from "cosmjs-types/cosmos/authz/v1beta1/tx";
 import { Any } from "../../../google/protobuf/any";
+import { Timestamp } from "../../../google/protobuf/timestamp";
 import { GenericAuthorization, AuthorizationType } from 'cosmjs-types/cosmos/authz/v1beta1/authz';
 import { SendAuthorization } from 'cosmjs-types/cosmos/bank/v1beta1/authz';
 import { StakeAuthorization } from 'cosmjs-types/cosmos/staking/v1beta1/authz';
+
 
 interface Grant {
   authorization?: any;


### PR DESCRIPTION
This PR will add Authz amino converter back to Cosmjs as it's working in Cosmos SDK again. Some review required on the usage of Bigint and Any object wrapped in AminoMsg.