### PR TITLE
fix: set date in advance during faucet to prevent multiple requests from the same address

### DIFF
--- a/packages/faucet/src/api/webserver.ts
+++ b/packages/faucet/src/api/webserver.ts
@@ -83,9 +83,9 @@ export class Webserver {
           }
 
           try {
-            await faucet.credit(address, matchingDenom);
             // Count addresses to prevent draining
             this.addressCounter.set(address, new Date());
+            await faucet.credit(address, matchingDenom);
           } catch (e) {
             console.error(e);
             throw new HttpError(500, "Sending tokens failed");


### PR DESCRIPTION
> Since the await faucet.credit(address, matchingDenom) call only returns when the transaction is in a block, the date is set too late. We should swap the two.

close #1556 