### PR TITLE
🐛 Fix inconsistent gas multiplier value between `signAndBroadcast` and `signAndBroadcastSync` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- @cosmjs/stargate, @cosmjs/cosmwasm-stargate: Synchronize the default gas
+multiplier value between the `signAndBroadcast` and `signAndBroadcastSync`
+methods so that it is equal to 1.4 everywhere. ([#1584])
+
 ## [0.32.3] - 2024-03-08
 
 ### Changed

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -202,6 +202,9 @@ export class SigningCosmWasmClient extends CosmWasmClient {
   private readonly signer: OfflineSigner;
   private readonly aminoTypes: AminoTypes;
   private readonly gasPrice: GasPrice | undefined;
+  // Starting with Cosmos SDK 0.47, we see many cases in which 1.3 is not enough anymore
+  // E.g. https://github.com/cosmos/cosmos-sdk/issues/16020
+  private readonly gasMultiplier = 1.4;
 
   /**
    * Creates an instance by connecting to the given CometBFT RPC endpoint.
@@ -614,9 +617,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     if (fee == "auto" || typeof fee === "number") {
       assertDefined(this.gasPrice, "Gas price must be set in the client options when auto gas is used.");
       const gasEstimation = await this.simulate(signerAddress, messages, memo);
-      // Starting with Cosmos SDK 0.47, we see many cases in which 1.3 is not enough anymore
-      // E.g. https://github.com/cosmos/cosmos-sdk/issues/16020
-      const multiplier = typeof fee === "number" ? fee : 1.4;
+      const multiplier = typeof fee === "number" ? fee : this.gasMultiplier;
       usedFee = calculateFee(Math.round(gasEstimation * multiplier), this.gasPrice);
     } else {
       usedFee = fee;
@@ -652,7 +653,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     if (fee == "auto" || typeof fee === "number") {
       assertDefined(this.gasPrice, "Gas price must be set in the client options when auto gas is used.");
       const gasEstimation = await this.simulate(signerAddress, messages, memo);
-      const multiplier = typeof fee === "number" ? fee : 1.3;
+      const multiplier = typeof fee === "number" ? fee : this.gasMultiplier;
       usedFee = calculateFee(Math.round(gasEstimation * multiplier), this.gasPrice);
     } else {
       usedFee = fee;

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -204,7 +204,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
   private readonly gasPrice: GasPrice | undefined;
   // Starting with Cosmos SDK 0.47, we see many cases in which 1.3 is not enough anymore
   // E.g. https://github.com/cosmos/cosmos-sdk/issues/16020
-  private readonly gasMultiplier = 1.4;
+  private readonly defaultGasMultiplier = 1.4;
 
   /**
    * Creates an instance by connecting to the given CometBFT RPC endpoint.
@@ -617,7 +617,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     if (fee == "auto" || typeof fee === "number") {
       assertDefined(this.gasPrice, "Gas price must be set in the client options when auto gas is used.");
       const gasEstimation = await this.simulate(signerAddress, messages, memo);
-      const multiplier = typeof fee === "number" ? fee : this.gasMultiplier;
+      const multiplier = typeof fee === "number" ? fee : this.defaultGasMultiplier;
       usedFee = calculateFee(Math.round(gasEstimation * multiplier), this.gasPrice);
     } else {
       usedFee = fee;
@@ -653,7 +653,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     if (fee == "auto" || typeof fee === "number") {
       assertDefined(this.gasPrice, "Gas price must be set in the client options when auto gas is used.");
       const gasEstimation = await this.simulate(signerAddress, messages, memo);
-      const multiplier = typeof fee === "number" ? fee : this.gasMultiplier;
+      const multiplier = typeof fee === "number" ? fee : this.defaultGasMultiplier;
       usedFee = calculateFee(Math.round(gasEstimation * multiplier), this.gasPrice);
     } else {
       usedFee = fee;

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -112,7 +112,7 @@ export class SigningStargateClient extends StargateClient {
   private readonly gasPrice: GasPrice | undefined;
   // Starting with Cosmos SDK 0.47, we see many cases in which 1.3 is not enough anymore
   // E.g. https://github.com/cosmos/cosmos-sdk/issues/16020
-  private readonly gasMultiplier = 1.4;
+  private readonly defaultGasMultiplier = 1.4;
 
   /**
    * Creates an instance by connecting to the given CometBFT RPC endpoint.
@@ -311,7 +311,7 @@ export class SigningStargateClient extends StargateClient {
     if (fee == "auto" || typeof fee === "number") {
       assertDefined(this.gasPrice, "Gas price must be set in the client options when auto gas is used.");
       const gasEstimation = await this.simulate(signerAddress, messages, memo);
-      const multiplier = typeof fee === "number" ? fee : this.gasMultiplier;
+      const multiplier = typeof fee === "number" ? fee : this.defaultGasMultiplier;
       usedFee = calculateFee(Math.round(gasEstimation * multiplier), this.gasPrice);
     } else {
       usedFee = fee;
@@ -338,7 +338,7 @@ export class SigningStargateClient extends StargateClient {
     if (fee == "auto" || typeof fee === "number") {
       assertDefined(this.gasPrice, "Gas price must be set in the client options when auto gas is used.");
       const gasEstimation = await this.simulate(signerAddress, messages, memo);
-      const multiplier = typeof fee === "number" ? fee : this.gasMultiplier;
+      const multiplier = typeof fee === "number" ? fee : this.defaultGasMultiplier;
       usedFee = calculateFee(Math.round(gasEstimation * multiplier), this.gasPrice);
     } else {
       usedFee = fee;

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -110,6 +110,9 @@ export class SigningStargateClient extends StargateClient {
   private readonly signer: OfflineSigner;
   private readonly aminoTypes: AminoTypes;
   private readonly gasPrice: GasPrice | undefined;
+  // Starting with Cosmos SDK 0.47, we see many cases in which 1.3 is not enough anymore
+  // E.g. https://github.com/cosmos/cosmos-sdk/issues/16020
+  private readonly gasMultiplier = 1.4;
 
   /**
    * Creates an instance by connecting to the given CometBFT RPC endpoint.
@@ -308,9 +311,7 @@ export class SigningStargateClient extends StargateClient {
     if (fee == "auto" || typeof fee === "number") {
       assertDefined(this.gasPrice, "Gas price must be set in the client options when auto gas is used.");
       const gasEstimation = await this.simulate(signerAddress, messages, memo);
-      // Starting with Cosmos SDK 0.47, we see many cases in which 1.3 is not enough anymore
-      // E.g. https://github.com/cosmos/cosmos-sdk/issues/16020
-      const multiplier = typeof fee === "number" ? fee : 1.4;
+      const multiplier = typeof fee === "number" ? fee : this.gasMultiplier;
       usedFee = calculateFee(Math.round(gasEstimation * multiplier), this.gasPrice);
     } else {
       usedFee = fee;
@@ -337,7 +338,7 @@ export class SigningStargateClient extends StargateClient {
     if (fee == "auto" || typeof fee === "number") {
       assertDefined(this.gasPrice, "Gas price must be set in the client options when auto gas is used.");
       const gasEstimation = await this.simulate(signerAddress, messages, memo);
-      const multiplier = typeof fee === "number" ? fee : 1.3;
+      const multiplier = typeof fee === "number" ? fee : this.gasMultiplier;
       usedFee = calculateFee(Math.round(gasEstimation * multiplier), this.gasPrice);
     } else {
       usedFee = fee;


### PR DESCRIPTION
Synchronizes the gas multiplier value between the `#signAndBroadcast` and `#signAndBroadcastSync` methods so that it is equal to `1.4` everywhere.