### PR TITLE
fix rpc client node info check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- @cosmjs/tendermint-rpc: fix node info check to accept empty string on channels
+  field ([#1591])
+
 ## [0.32.3] - 2024-03-08
 
 ### Changed

--- a/packages/tendermint-rpc/src/comet38/adaptor/responses.ts
+++ b/packages/tendermint-rpc/src/comet38/adaptor/responses.ts
@@ -599,7 +599,7 @@ function decodeNodeInfo(data: RpcNodeInfo): responses.NodeInfo {
     listenAddr: assertNotEmpty(data.listen_addr),
     network: assertNotEmpty(data.network),
     version: assertString(data.version), // Can be empty (https://github.com/cosmos/cosmos-sdk/issues/7963)
-    channels: assertNotEmpty(data.channels),
+    channels: assertString(data.channels), // can be empty
     moniker: assertNotEmpty(data.moniker),
     other: dictionaryToStringMap(data.other),
     protocolVersion: {

--- a/packages/tendermint-rpc/src/tendermint37/adaptor/responses.ts
+++ b/packages/tendermint-rpc/src/tendermint37/adaptor/responses.ts
@@ -597,7 +597,7 @@ function decodeNodeInfo(data: RpcNodeInfo): responses.NodeInfo {
     listenAddr: assertNotEmpty(data.listen_addr),
     network: assertNotEmpty(data.network),
     version: assertString(data.version), // Can be empty (https://github.com/cosmos/cosmos-sdk/issues/7963)
-    channels: assertNotEmpty(data.channels),
+    channels: assertString(data.channels), // can be empty
     moniker: assertNotEmpty(data.moniker),
     other: dictionaryToStringMap(data.other),
     protocolVersion: {


### PR DESCRIPTION
channels field from the node info is specifically used by cometbft p2p system, but in cases like rollkit where that is not used this can be an empty string.

This changes the assert from not empty to only assert is string that was preventing stargate client to initialize correctly.
see example: 
https://rpc.rosm.rollkit.dev/status