### PR TITLE
backport 0.31x: add http timeout & more data decode tx resp

### DIFF
--- a/packages/stargate/src/stargateclient.ts
+++ b/packages/stargate/src/stargateclient.ts
@@ -510,6 +510,7 @@ export class StargateClient {
     return results.txs.map((tx): IndexedTx => {
       const txMsgData = TxMsgData.decode(tx.result.data ?? new Uint8Array());
       return {
+        ...tx,
         height: tx.height,
         txIndex: tx.index,
         hash: toHex(tx.hash).toUpperCase(),

--- a/packages/tendermint-rpc/src/rpcclients/http.ts
+++ b/packages/tendermint-rpc/src/rpcclients/http.ts
@@ -40,9 +40,14 @@ export async function http(
   headers: Record<string, string> | undefined,
   request?: any,
 ): Promise<any> {
+  const timeout = Number(
+    //@ts-ignore
+    process.env.HTTP_TIMEOUT || 30000,
+  );
   if (typeof fetch === "function" && !isExperimental(fetch)) {
     const settings = {
       method: method,
+      signal: timeout,
       body: request ? JSON.stringify(request) : undefined,
       headers: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -55,7 +60,7 @@ export async function http(
       .then((res: any) => res.json());
   } else {
     return axios
-      .request({ url: url, method: method, data: request, headers: headers })
+      .request({ url: url, method: method, data: request, headers: headers, timeout })
       .then((res) => res.data);
   }
 }

--- a/packages/tendermint-rpc/src/tendermint34/adaptor/responses.ts
+++ b/packages/tendermint-rpc/src/tendermint34/adaptor/responses.ts
@@ -723,6 +723,7 @@ interface RpcTxResponse {
 
 function decodeTxResponse(data: RpcTxResponse): responses.TxResponse {
   return {
+    ...data,
     tx: fromBase64(assertNotEmpty(data.tx)),
     result: decodeTxData(assertObject(data.tx_result)),
     height: apiToSmallInt(assertNotEmpty(data.height)),

--- a/packages/tendermint-rpc/src/tendermint37/adaptor/responses.ts
+++ b/packages/tendermint-rpc/src/tendermint37/adaptor/responses.ts
@@ -724,6 +724,7 @@ interface RpcTxResponse {
 
 function decodeTxResponse(data: RpcTxResponse): responses.TxResponse {
   return {
+    ...data,
     tx: fromBase64(assertNotEmpty(data.tx)),
     result: decodeTxData(assertObject(data.tx_result)),
     height: apiToSmallInt(assertNotEmpty(data.height)),


### PR DESCRIPTION
- Add a timeout value for the `http()` function, preventing long requests from hanging.
- Return additional data fields in `decodeTxResponse` in case of custom responses like timestamp, block info...
- Return additional tx fields in `txsQuery` of StargateClient for custom query responses.

We have been patching this in different projects for quite some time. Eg: [oraidex-sdk](https://github.com/oraichain/oraidex-sdk/blob/main/patches/%40cosmjs%2Btendermint-rpc%2B0.31.3.patch)

It would be inconvenient to just include patch logic in every repository we need. Also, contributing to cosmjs is also a good way to help improve the tool for the community