### PR TITLE
Expose explicitSignerData for simulation method and reduce rpc node requests

### DIFF
--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.spec.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.spec.ts
@@ -102,6 +102,32 @@ describe("SigningCosmWasmClient", () => {
       expect(gasUsed).toBeLessThanOrEqual(140_000);
       client.disconnect();
     });
+    it("works with explicitSignerData", async () => {
+      pendingWithoutWasmd();
+      const wallet = await DirectSecp256k1HdWallet.fromMnemonic(alice.mnemonic, { prefix: wasmd.prefix });
+      const client = await SigningCosmWasmClient.connectWithSigner(
+        wasmd.endpoint,
+        wallet,
+        defaultSigningClientOptions,
+      );
+
+      const executeContractMsg: MsgExecuteContractEncodeObject = {
+        typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
+        value: MsgExecuteContract.fromPartial({
+          sender: alice.address0,
+          contract: deployedHackatom.instances[0].address,
+          msg: toUtf8(`{"release":{}}`),
+          funds: [],
+        }),
+      };
+      const memo = "Go go go";
+      const { sequence } = await client.getSequence(alice.address0)
+
+      const gasUsed = await client.simulate(alice.address0, [executeContractMsg], memo, { sequence });
+      expect(gasUsed).toBeGreaterThanOrEqual(70_000);
+      expect(gasUsed).toBeLessThanOrEqual(140_000);
+      client.disconnect();
+    });
   });
 
   describe("upload", () => {

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -623,15 +623,27 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     timeoutHeight?: bigint,
   ): Promise<DeliverTxResponse> {
     let usedFee: StdFee;
+
+    const { accountNumber, sequence } = await this.getSequence(signerAddress);
+
     if (fee == "auto" || typeof fee === "number") {
       assertDefined(this.gasPrice, "Gas price must be set in the client options when auto gas is used.");
-      const gasEstimation = await this.simulate(signerAddress, messages, memo);
+      const gasEstimation = await this.simulate(signerAddress, messages, memo, { sequence });
       const multiplier = typeof fee === "number" ? fee : this.defaultGasMultiplier;
       usedFee = calculateFee(Math.round(gasEstimation * multiplier), this.gasPrice);
     } else {
       usedFee = fee;
     }
-    const txRaw = await this.sign(signerAddress, messages, usedFee, memo, undefined, timeoutHeight);
+
+    const chainId = await this.getChainId();
+
+    const signerData: SignerData = {
+      accountNumber: accountNumber,
+      sequence: sequence,
+      chainId: chainId,
+    };
+
+    const txRaw = await this.sign(signerAddress, messages, usedFee, memo, signerData, timeoutHeight);
     const txBytes = TxRaw.encode(txRaw).finish();
     return this.broadcastTx(txBytes, this.broadcastTimeoutMs, this.broadcastPollIntervalMs);
   }

--- a/packages/stargate/src/signingstargateclient.spec.ts
+++ b/packages/stargate/src/signingstargateclient.spec.ts
@@ -88,6 +88,33 @@ describe("SigningStargateClient", () => {
 
       client.disconnect();
     });
+    it("works with explicitSignerData", async () => {
+      pendingWithoutSimapp();
+      const wallet = await DirectSecp256k1HdWallet.fromMnemonic(faucet.mnemonic);
+      const client = await SigningStargateClient.connectWithSigner(
+        simapp.tendermintUrlHttp,
+        wallet,
+        defaultSigningClientOptions,
+      );
+
+      const msg = MsgDelegate.fromPartial({
+        delegatorAddress: faucet.address0,
+        validatorAddress: validator.validatorAddress,
+        amount: coin(1234, "ustake"),
+      });
+      const msgAny: MsgDelegateEncodeObject = {
+        typeUrl: "/cosmos.staking.v1beta1.MsgDelegate",
+        value: msg,
+      };
+      const memo = "Use your power wisely";
+
+      const { sequence } = await client.getSequence(faucet.address0)
+      const gasUsed = await client.simulate(faucet.address0, [msgAny], memo, { sequence });
+      expect(gasUsed).toBeGreaterThanOrEqual(101_000);
+      expect(gasUsed).toBeLessThanOrEqual(200_000);
+
+      client.disconnect();
+    });
   });
 
   describe("sendTokens", () => {

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -179,6 +179,7 @@ export class SigningStargateClient extends StargateClient {
     signerAddress: string,
     messages: readonly EncodeObject[],
     memo: string | undefined,
+    explicitSignerData?: Partial<SignerData>,
   ): Promise<number> {
     const anyMsgs = messages.map((m) => this.registry.encodeAsAny(m));
     const accountFromSigner = (await this.signer.getAccounts()).find(
@@ -188,7 +189,15 @@ export class SigningStargateClient extends StargateClient {
       throw new Error("Failed to retrieve account from signer");
     }
     const pubkey = encodeSecp256k1Pubkey(accountFromSigner.pubkey);
-    const { sequence } = await this.getSequence(signerAddress);
+
+    let sequence: number
+
+    if (explicitSignerData?.sequence !== undefined) {
+      sequence = explicitSignerData.sequence;
+    } else {
+      sequence = (await this.getSequence(signerAddress)).sequence;
+    }
+
     const { gasInfo } = await this.forceGetQueryClient().tx.simulate(anyMsgs, memo, pubkey, sequence);
     assertDefined(gasInfo);
     return Uint53.fromString(gasInfo.gasUsed.toString()).toNumber();


### PR DESCRIPTION
At the moment when we want to perform a simulation, using the `simulate` method exposed in the `SigningCosmWasmClient` and `SigningCosmWasmClient` classes, it is not possible to specify the `sequence`, but a request is made each time to get it.

However, this in practical use results in sending multiple requests to the RPC nodes, for example when we go to use the `signAndBroadcast` method at the moment three requests are made to the nodes:
1) getAccount (fetched by the `simulation` method)
2) getAccount (fetched by the `sign` method)
3) getStatus

So we make the same request twice in a row to get the account details, specifically `sequence` and `accountNumber`.

The goal of this PR is to remove this redundancy and reduce the number of requests made to nodes in the chain.