### PR TITLE
feat: allow to specify an AccountParser inside CosmWasmClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- @cosmjs/cosmwasm-stargate: Added the ability to specify a custom account parser for `CosmWasmClient`
+
 ## [0.32.4] - 2024-06-26
 
 ### Fixed

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -50,7 +50,7 @@ import {
 import { AccessConfig } from "cosmjs-types/cosmwasm/wasm/v1/types";
 import pako from "pako";
 
-import { CosmWasmClient } from "./cosmwasmclient";
+import { CosmWasmClient, CosmWasmClientOptions } from "./cosmwasmclient";
 import {
   createWasmAminoConverters,
   JsonObject,
@@ -186,7 +186,7 @@ function createDeliverTxResponseErrorMessage(result: DeliverTxResponse): string 
   return `Error when broadcasting tx ${result.transactionHash} at height ${result.height}. Code: ${result.code}; Raw log: ${result.rawLog}`;
 }
 
-export interface SigningCosmWasmClientOptions {
+export interface SigningCosmWasmClientOptions extends CosmWasmClientOptions {
   readonly registry?: Registry;
   readonly aminoTypes?: AminoTypes;
   readonly broadcastTimeoutMs?: number;
@@ -254,7 +254,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     signer: OfflineSigner,
     options: SigningCosmWasmClientOptions,
   ) {
-    super(cometClient);
+    super(cometClient, options);
     const {
       registry = new Registry([...defaultStargateTypes, ...wasmTypes]),
       aminoTypes = new AminoTypes({


### PR DESCRIPTION
- Similarly to https://github.com/cosmos/cosmjs/pull/1102 but for CosmWasmClient
- Needed for adding a custom accountParser for reading custom accounts
  - Potentially solves an issue relating to nibijs with Keplr Accounts https://github.com/NibiruChain/ts-sdk/issues/371, already created an account parser https://github.com/NibiruChain/ts-sdk/pull/374