### PR TITLE
[Bugfix] replace comet38 `begin/end_block_events` with `finalize_block_events`

### DIFF
--- a/packages/tendermint-rpc/src/comet38/adaptor/responses.ts
+++ b/packages/tendermint-rpc/src/comet38/adaptor/responses.ts
@@ -287,8 +287,7 @@ export function decodeValidatorUpdate(data: RpcValidatorUpdate): responses.Valid
 interface RpcBlockResultsResponse {
   readonly height: string;
   readonly txs_results: readonly RpcTxData[] | null;
-  readonly begin_block_events: readonly RpcEvent[] | null;
-  readonly end_block_events: readonly RpcEvent[] | null;
+  readonly finalize_block_events: readonly RpcEvent[] | null;
   readonly validator_updates: readonly RpcValidatorUpdate[] | null;
   readonly consensus_param_updates: RpcConsensusParams | null;
 }
@@ -299,8 +298,7 @@ function decodeBlockResults(data: RpcBlockResultsResponse): responses.BlockResul
     results: (data.txs_results || []).map(decodeTxData),
     validatorUpdates: (data.validator_updates || []).map(decodeValidatorUpdate),
     consensusUpdates: may(decodeConsensusParams, data.consensus_param_updates),
-    beginBlockEvents: decodeEvents(data.begin_block_events || []),
-    endBlockEvents: decodeEvents(data.end_block_events || []),
+    finalizeBlockEvents: decodeEvents(data.finalize_block_events || [])
   };
 }
 

--- a/packages/tendermint-rpc/src/comet38/comet38client.spec.ts
+++ b/packages/tendermint-rpc/src/comet38/comet38client.spec.ts
@@ -261,8 +261,7 @@ function defaultTestSuite(rpcFactory: () => RpcClient, expected: ExpectedValues)
       const results = await client.blockResults(height);
       expect(results.height).toEqual(height);
       expect(results.results).toEqual([]);
-      expect(results.beginBlockEvents).toEqual([]);
-      expect(results.endBlockEvents).toEqual([]);
+      expect(results.finalizeBlockEvents).toEqual([]);
 
       client.disconnect();
     });

--- a/packages/tendermint-rpc/src/comet38/responses.ts
+++ b/packages/tendermint-rpc/src/comet38/responses.ts
@@ -60,8 +60,7 @@ export interface BlockResultsResponse {
   readonly results: readonly TxData[];
   readonly validatorUpdates: readonly ValidatorUpdate[];
   readonly consensusUpdates?: ConsensusParams;
-  readonly beginBlockEvents: readonly Event[];
-  readonly endBlockEvents: readonly Event[];
+  readonly finalizeBlockEvents: readonly Event[];
 }
 
 export interface BlockSearchResponse {


### PR DESCRIPTION
As of cometbft v0.38.x, [`BeginBlock` and `EndBlock` are combined into `FinalizeBlock`](https://docs.cometbft.com/v0.38/guides/go-built-in#133-finalizeblock). This has a knock-on effect through the RPC response types which has as of yet to be resolved in mainline cosmjs.

Compare `cometbft/rpc/core/types.ResultBlockResults` between versions [v0.37.x](https://github.com/cometbft/cometbft/blob/v0.37.x/rpc/core/types/responses.go#L57) and [v0.38.x](https://github.com/cometbft/cometbft/blob/v0.38.x/rpc/core/types/responses.go#L57):

```diff
// ABCI results from a block
type ResultBlockResults struct {
	Height                int64                     `json:"height"`
	TxsResults            []*abci.ResponseDeliverTx `json:"txs_results"`
-	BeginBlockEvents      []abci.Event              `json:"begin_block_events"`
-	EndBlockEvents        []abci.Event              `json:"end_block_events"`
+	FinalizeBlockEvents   []abci.Event              `json:"finalize_block_events"`
	ValidatorUpdates      []abci.ValidatorUpdate    `json:"validator_updates"`
	ConsensusParamUpdates *cmtproto.ConsensusParams `json:"consensus_param_updates"`
}
```