### PR TITLE
fix: update `signAmino` method to use `messages` directly

### DIFF
--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -405,7 +405,7 @@ export class SigningStargateClient extends StargateClient {
     const signDoc = makeSignDocAmino(msgs, fee, chainId, memo, accountNumber, sequence, timeoutHeight);
     const { signature, signed } = await this.signer.signAmino(signerAddress, signDoc);
     const signedTxBody = {
-      messages: signed.msgs.map((msg) => this.aminoTypes.fromAmino(msg)),
+      messages,
       memo: signed.memo,
       timeoutHeight: timeoutHeight,
     };


### PR DESCRIPTION
This change simplifies the code by removing unnecessary mapping of messages.

This PR also acts as a workaround for https://github.com/cosmology-tech/telescope/issues/660 where `toAmino` and `fromAmino` are not symmetrical.

The [ManifestJS](https://github.com/liftedinit/manifestjs) and [Manifest WebApp](https://github.com/liftedinit/manifest-app) projects use this fix. Both project are now able to properly sign AMINO transactions, including using Keplr and Ledger in-browser.

[ManifestJS](https://github.com/liftedinit/manifestjs) has a Starship test suite covering some of the use-cases that are failing without this fix.