### PR TITLE
typo-Update README.md

### DIFF
--- a/packages/faucet/README.md
+++ b/packages/faucet/README.md
@@ -61,7 +61,7 @@ FAUCET_TOKENS             A comma separated list of token denoms, e.g.
                           "uatom" or "ucosm, mstake".
 FAUCET_CREDIT_AMOUNT_TKN  Send this amount of TKN to a user requesting TKN. TKN is
                           a placeholder for the token's denom. Defaults to 10000000.
-FAUCET_REFILL_FACTOR      Send factor times credit amount on refilling. Defauls to 8.
+FAUCET_REFILL_FACTOR      Send factor times credit amount on refilling. Defaults to 8.
 FAUCET_REFILL_THRESHOLD   Refill when balance gets below factor times credit amount.
                           Defaults to 20.
 FAUCET_COOLDOWN_TIME      Time (in seconds) after which an address can request


### PR DESCRIPTION
# Fix: Corrected typo in README.md

## Changes
1. **File**: `packages/faucet/README.md`
   - Corrected "Defauls" to "Defaults".

   - **Before**:
     ```markdown
     Defauls
     ```
   - **After**:
     ```markdown
     Defaults 
     ```

## Purpose
- Improved documentation accuracy by fixing the typographical error.
- Enhanced the readability and professionalism of the README file.
