### PR TITLE
bump elliptic dependencies package to 6.6.1

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -1159,7 +1159,7 @@ const RAW_RUNTIME_STATE =
     ],\
     [\
       "elliptic",\
-      "npm:6.5.4"\
+      "npm:6.6.1"\
     ],\
     [\
       "emoji-regex",\
@@ -3399,7 +3399,7 @@ const RAW_RUNTIME_STATE =
           ["@typescript-eslint/parser", "virtual:4f1584ad4aba8733a24be7c8aebbffafef25607f2d00f4b314cf96717145c692763628a31c2b85d4686fbb091ff21ebffa3cc337399c042c19a32b9bdb786464#npm:5.54.0"],\
           ["bn.js", "npm:5.2.0"],\
           ["buffer", "npm:6.0.3"],\
-          ["elliptic", "npm:6.5.4"],\
+          ["elliptic", "npm:6.6.1"],\
           ["eslint", "npm:7.26.0"],\
           ["eslint-config-prettier", "virtual:4f1584ad4aba8733a24be7c8aebbffafef25607f2d00f4b314cf96717145c692763628a31c2b85d4686fbb091ff21ebffa3cc337399c042c19a32b9bdb786464#npm:8.3.0"],\
           ["eslint-import-resolver-node", "npm:0.3.4"],\
@@ -7527,10 +7527,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["elliptic", [\
-      ["npm:6.5.4", {\
-        "packageLocation": "./.yarn/cache/elliptic-npm-6.5.4-0ca8204a86-5f36127029.zip/node_modules/elliptic/",\
+      ["npm:6.6.1", {\
+        "packageLocation": "./.yarn/cache/elliptic-npm-6.6.1-87bb857cbc-8b24ef782e.zip/node_modules/elliptic/",\
         "packageDependencies": [\
-          ["elliptic", "npm:6.5.4"],\
+          ["elliptic", "npm:6.6.1"],\
           ["bn.js", "npm:4.12.0"],\
           ["brorand", "npm:1.1.0"],\
           ["hash.js", "npm:1.1.7"],\

--- a/.yarn/cache/elliptic-npm-6.5.4-0ca8204a86-5f36127029.zip
+++ b/.yarn/cache/elliptic-npm-6.5.4-0ca8204a86-5f36127029.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:90d79078c59fce7955ad2e1804990e4035fde8f96c76d6a6c89d0035b41209ff
-size 122475

--- a/.yarn/cache/elliptic-npm-6.6.1-87bb857cbc-8b24ef782e.zip
+++ b/.yarn/cache/elliptic-npm-6.6.1-87bb857cbc-8b24ef782e.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d6bf45f543102131960445b810961fccfcc4466cd490e61478d3921d20ed6fe
+size 124143

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -46,7 +46,7 @@
     "@cosmjs/utils": "workspace:^",
     "@noble/hashes": "^1",
     "bn.js": "^5.2.0",
-    "elliptic": "^6.5.4",
+    "elliptic": "^6.6.1",
     "libsodium-wrappers-sumo": "^0.7.11"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -446,7 +446,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^5.54.0"
     bn.js: "npm:^5.2.0"
     buffer: "npm:^6.0.3"
-    elliptic: "npm:^6.5.4"
+    elliptic: "npm:^6.6.1"
     eslint: "npm:^7.5"
     eslint-config-prettier: "npm:^8.3.0"
     eslint-import-resolver-node: "npm:^0.3.4"
@@ -3352,9 +3352,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:^6.5.4":
-  version: 6.5.4
-  resolution: "elliptic@npm:6.5.4"
+"elliptic@npm:^6.6.1":
+  version: 6.6.1
+  resolution: "elliptic@npm:6.6.1"
   dependencies:
     bn.js: "npm:^4.11.9"
     brorand: "npm:^1.1.0"
@@ -3363,7 +3363,7 @@ __metadata:
     inherits: "npm:^2.0.4"
     minimalistic-assert: "npm:^1.0.1"
     minimalistic-crypto-utils: "npm:^1.0.1"
-  checksum: 10c0/5f361270292c3b27cf0843e84526d11dec31652f03c2763c6c2b8178548175ff5eba95341dd62baff92b2265d1af076526915d8af6cc9cb7559c44a62f8ca6e2
+  checksum: 10c0/8b24ef782eec8b472053793ea1e91ae6bee41afffdfcb78a81c0a53b191e715cbe1292aa07165958a9bbe675bd0955142560b1a007ffce7d6c765bcaf951a867
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the elliptic package to resolve [GHSA-vjh7-7g9h-fjfh](https://github.com/indutny/elliptic/security/advisories/GHSA-vjh7-7g9h-fjfh), which identifies a security vulnerability in the affected versions. 
