### PR TITLE
fix: Rename parameter 'data' to 'value' in isJsonCompatibleDictionary for consistency

### DIFF
--- a/packages/json-rpc/src/compatibility.ts
+++ b/packages/json-rpc/src/compatibility.ts
@@ -54,18 +54,18 @@ export function isJsonCompatibleArray(value: unknown): value is JsonCompatibleAr
   return true;
 }
 
-export function isJsonCompatibleDictionary(data: unknown): data is JsonCompatibleDictionary {
-  if (typeof data !== "object" || data === null) {
-    // data must be a non-null object
+export function isJsonCompatibleDictionary(value: unknown): value is JsonCompatibleDictionary {
+  if (typeof value !== "object" || value === null) {
+    // value must be a non-null object
     return false;
   }
 
   // Exclude special kind of objects like Array, Date or Uint8Array
   // Object.prototype.toString() returns a specified value:
   // http://www.ecma-international.org/ecma-262/7.0/index.html#sec-object.prototype.tostring
-  if (Object.prototype.toString.call(data) !== "[object Object]") {
+  if (Object.prototype.toString.call(value) !== "[object Object]") {
     return false;
   }
 
-  return Object.values(data).every(isJsonCompatibleValue);
+  return Object.values(value).every(isJsonCompatibleValue);
 }


### PR DESCRIPTION
- Standardizes parameter naming across JSON compatibility check functions
- Updates related comments to match the new parameter name