### PR TITLE
Added nonCriticalExtensionOptions and fee granter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- @cosmjs/stargate: Support `nonCriticalExtensionOptions` when generating
+  transactions
+- @cosmjs/cosmwasm-stargate: Support `nonCriticalExtensionOptions` and fee
+  granter when signing and executing transactions
+
 ## [0.33.1] - 2025-03-12
 
 ### Fixed

--- a/packages/cosmwasm-stargate/src/index.ts
+++ b/packages/cosmwasm-stargate/src/index.ts
@@ -24,6 +24,7 @@ export {
 } from "./modules";
 export {
   ChangeAdminResult,
+  CustomTxOptions,
   ExecuteInstruction,
   ExecuteResult,
   InstantiateOptions,

--- a/packages/stargate/src/modules/tx/queries.ts
+++ b/packages/stargate/src/modules/tx/queries.ts
@@ -21,6 +21,7 @@ export interface TxExtension {
       memo: string | undefined,
       signer: Pubkey,
       sequence: number,
+      nonCriticalExtensionOptions?: readonly Any[],
     ) => Promise<SimulateResponse>;
     // Add here with tests:
     // - broadcastTx
@@ -48,6 +49,7 @@ export function setupTxExtension(base: QueryClient): TxExtension {
         memo: string | undefined,
         signer: Pubkey,
         sequence: number,
+        nonCriticalExtensionOptions?: readonly Any[],
       ) => {
         const tx = Tx.fromPartial({
           authInfo: AuthInfo.fromPartial({
@@ -63,6 +65,8 @@ export function setupTxExtension(base: QueryClient): TxExtension {
           body: TxBody.fromPartial({
             messages: Array.from(messages),
             memo: memo,
+            nonCriticalExtensionOptions:
+              nonCriticalExtensionOptions && Array.from(nonCriticalExtensionOptions),
           }),
           signatures: [new Uint8Array()],
         });


### PR DESCRIPTION
## Description

This adds support for `nonCriticalExtensionOptions` in transactions, which is necessary for using inscriptions via `/gaia.metaprotocols.ExtensionData`.

This also adds support for specifying the fee granter to use when executing a transaction. Technically the `StdFee` already allows specifying the fee granter, but not if you let cosmjs simulate gas to calculate the fee to use.