### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected