### PR TITLE
clarify roadmap section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,8 @@ module.exports = [
 
 ## Roadmap
 
-We maintain a [development board](https://github.com/orgs/cosmos/projects/6),
-use [release milestones](https://github.com/cosmos/cosmjs/milestones) and share
-important updates in the [CosmWasm Community Call]. For higher level roadmap
-discussion please reach out to the team.
+We use [release milestones](https://github.com/cosmos/cosmjs/milestones) and share important updates in the [CosmWasm Community Call]. For higher level roadmap discussion, please reach out to the team. You can also explore key capabilities and ongoing innovations on Cosmos Network [Features page](https://cosmos.network/features/).
+
 
 [cosmwasm community call]:
   https://github.com/CosmWasm/cosmwasm/issues?q=label%3A%22Community+Call+%F0%9F%97%BA%F0%9F%93%9E%22


### PR DESCRIPTION


In my opinion, the updated roadmap section reads more clearly now

Adding the [Cosmos Network Features page](https://cosmos.network/features/) is a good addition for readers looking for a broader view of the ecosystem.
