### PR TITLE
fix outdated docs

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -6,7 +6,7 @@ work on CosmJS, i.e. modify it. It is not intended for users of CosmJS.
 ## Prerequisite
 
 - A UNIX-like development environment
-- Node.js 14+, Docker and yarn
+- Node.js 18+, Docker and yarn
 - `sha256sum`, which you
   [can get on macOS as well](https://unix.stackexchange.com/questions/426837/no-sha256sum-in-macos)
 - `gsed`, which you
@@ -15,7 +15,7 @@ work on CosmJS, i.e. modify it. It is not intended for users of CosmJS.
 ## Checking out code
 
 We use Git for version control. In addition to the well-known basics, we use the
-extension Git Large File Storage (LFS) to store blobs (currently \*.png and
+extension Git Large File Storage (LFS) to store blobs (currently \*.zip, \*.png, and
 \*.wasm). A git-lfs package is available directly in modern package repositories
 (Debian 10+, Ubuntu 18.04+, Homebrew, MacPorts) and as a backport for older
 systems. Please see [this website](https://git-lfs.github.com/) for instructions

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ optipng docs/cosmjs-tree*.png
 
 Currently the codebase supports the following runtime environments:
 
-1. Node.js 14+
+1. Node.js 18+
 2. Modern browsers (Chromium/Firefox/Safari, no Internet Explorer or
    [Edge Spartan](https://en.wikipedia.org/wiki/Microsoft_Edge#Development))
 3. Browser extensions (Chromium/Firefox)


### PR DESCRIPTION
Node.js 14 and 16 were dropped in #1473 #1622

.zip added to git LFS in #788
https://github.com/cosmos/cosmjs/pull/788/commits/f7a5cc5fc1eed03a103f425344e1474c8ea75bad