### PR TITLE
Fix: update broken Yarn documentation links to valid URLs

### DIFF
--- a/docs/YARN.md
+++ b/docs/YARN.md
@@ -368,7 +368,7 @@ you’ll want to add to VCS. If you’re using VSCode, it will also add some stu
 to `.vscode/extensions.json` and `.vscode/settings.json`. You may or may not
 want to add these to VCS—talk to your colleagues.
 
-https://next.yarnpkg.com/advanced/pnpify#ide-support
+https://yarnpkg.com/advanced/pnpify#ide-support
 
 ## Step 15: Switch versioning from Lerna to Yarn
 
@@ -376,7 +376,7 @@ Lerna unfortunately appears to be unmaintained. Remove the dependency and the
 `lerna.json` configuration file.
 
 You can read about Yarn’s release workflow here:
-https://next.yarnpkg.com/features/release-workflow
+https://yarnpkg.com/features/release-workflow
 
 ## Step 16: Consider using constraints
 


### PR DESCRIPTION
Replaced two outdated and broken links in the Yarn migration guide with their current, working counterparts:
- Updated the PnPify IDE support link to https://yarnpkg.com/advanced/pnpify#ide-support
- Updated the release workflow link to https://yarnpkg.com/features/release-workflow
This ensures readers are directed to the correct and up-to-date Yarn documentation.