### PR TITLE
Fix duplicate condition check in CustomMsgDelegate encode method

### DIFF
--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.spec.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.spec.ts
@@ -1468,7 +1468,7 @@ describe("SigningCosmWasmClient", () => {
           encode(message: CustomMsgDelegate, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
             writer.uint32(10).string(message.customDelegatorAddress ?? "");
             writer.uint32(18).string(message.customValidatorAddress ?? "");
-            if (message.customAmount !== undefined && message.customAmount !== undefined) {
+            if (message.customAmount !== undefined) {
               Coin.encode(message.customAmount, writer.uint32(26).fork()).ldelim();
             }
             return writer;

--- a/packages/stargate/src/signingstargateclient.spec.ts
+++ b/packages/stargate/src/signingstargateclient.spec.ts
@@ -1080,7 +1080,7 @@ describe("SigningStargateClient", () => {
           encode(message: CustomMsgDelegate, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
             writer.uint32(10).string(message.customDelegatorAddress ?? "");
             writer.uint32(18).string(message.customValidatorAddress ?? "");
-            if (message.customAmount !== undefined && message.customAmount !== undefined) {
+            if (message.customAmount !== undefined) {
               Coin.encode(message.customAmount, writer.uint32(26).fork()).ldelim();
             }
             return writer;


### PR DESCRIPTION
This PR fixes a redundant condition check in the encode method of CustomMsgDelegate. The current implementation checks message.customAmount !== undefined twice in the same if statement, which is unnecessary. This change simplifies the code by removing the duplicate check while maintaining the same functionality.

The fix makes the code cleaner and more maintainable without changing the behavior of the application.