### PR TITLE
fix typos in documentation and comments

### DIFF
--- a/packages/amino/src/omitdefault.ts
+++ b/packages/amino/src/omitdefault.ts
@@ -1,6 +1,6 @@
 /**
  * Returns the given input. If the input is the default value
- * of protobuf, undefined is retunred. Use this when creating Amino JSON converters.
+ * of protobuf, undefined is returned. Use this when creating Amino JSON converters.
  */
 export function omitDefault<T extends string | number | bigint | boolean>(input: T): T | undefined {
   switch (typeof input) {

--- a/packages/tendermint-rpc/README.md
+++ b/packages/tendermint-rpc/README.md
@@ -4,7 +4,7 @@
 
 This package provides a type-safe wrapper around
 [Tendermint RPC](https://docs.tendermint.com/master/rpc/). Notably, all binary
-data is passed in and out as `Uint8Array`, and this module is reponsible for the
+data is passed in and out as `Uint8Array`, and this module is responsible for the
 hex/base64 encoding/decoding depending on the field and version of Tendermint.
 Also handles converting numbers to and from strings.
 

--- a/packages/tendermint-rpc/src/comet38/adaptor/responses.ts
+++ b/packages/tendermint-rpc/src/comet38/adaptor/responses.ts
@@ -778,7 +778,7 @@ interface RpcBlock {
     /** Raw tx bytes, base64 encoded */
     readonly txs?: readonly string[];
   };
-  // It's currently unclear why the deep nesting is requied.
+  // It's currently unclear why the deep nesting is required.
   // See https://github.com/tendermint/tendermint/issues/7697.
   readonly evidence?: {
     readonly evidence?: readonly RpcEvidence[];


### PR DESCRIPTION


**Description:**
This pull request contains changes to improve clarity, correctness and structure.

1. Corrected `retunred` → `returned`
2. Corrected `reponsible` → `responsible`
3. Corrected `requied` → `required`
