### PR TITLE
use an address length limit compatible with ibc-go

### DIFF
--- a/packages/faucet/src/addresses.spec.ts
+++ b/packages/faucet/src/addresses.spec.ts
@@ -24,6 +24,10 @@ describe("isValidAddress", () => {
     expect(isValidAddress("cosmos1fail", "cosmos")).toBe(false);
   });
 
+  it("rejects a zero-length address", () => {
+    expect(isValidAddress("cosmos1550dq7", "cosmos")).toBe(false);
+  });
+
   it("requires a prefix argument", () => {
     // @ts-expect-error intentionally omitting an argument
     expect(isValidAddress("cosmos1h806c7khnvmjlywdrkdgk2vrayy2mmvf9rxk2r")).toBe(false);

--- a/packages/faucet/src/addresses.spec.ts
+++ b/packages/faucet/src/addresses.spec.ts
@@ -11,6 +11,15 @@ describe("isValidAddress", () => {
     );
   });
 
+  it("accepts a Penumbra compat address", () => {
+    expect(
+      isValidAddress(
+        "penumbracompat11ld2kghffzgwq4597ejpgmnwxa7ju0cndytuxtsjh8qhjyfuwq0rwd5flnw4a3fgclw7m5puh50nskn2c88flhne2hzchnpxru609d5wgmqqvhdf0sy2tktqfcm2p2tmxeuc86n",
+        "penumbracompat1",
+      ),
+    ).toBe(true);
+  });
+
   it("rejects an invalid address", () => {
     expect(isValidAddress("cosmos1fail", "cosmos")).toBe(false);
   });

--- a/packages/faucet/src/addresses.ts
+++ b/packages/faucet/src/addresses.ts
@@ -1,12 +1,15 @@
 import { fromBech32 } from "@cosmjs/encoding";
 
 export function isValidAddress(input: string, requiredPrefix: string): boolean {
+  if (input.length > 2048) {
+    return false;
+  }
   try {
     const { prefix, data } = fromBech32(input);
     if (prefix !== requiredPrefix) {
       return false;
     }
-    return data.length >= 20 && data.length <= 32;
+    return data.length >= 20;
   } catch {
     return false;
   }

--- a/packages/faucet/src/addresses.ts
+++ b/packages/faucet/src/addresses.ts
@@ -1,15 +1,16 @@
 import { fromBech32 } from "@cosmjs/encoding";
 
+// Penumbra are up to 150 chars. ibc-go has a limit of 2048.
+// See https://github.com/cosmos/cosmjs/pull/1674
+const lengthLimit = 512;
+
 export function isValidAddress(input: string, requiredPrefix: string): boolean {
-  if (input.length > 2048) {
-    return false;
-  }
   try {
-    const { prefix, data } = fromBech32(input);
+    const { prefix, data } = fromBech32(input, lengthLimit);
     if (prefix !== requiredPrefix) {
       return false;
     }
-    return data.length >= 20;
+    return data.length >= 20 && data.length <= 128;
   } catch {
     return false;
   }


### PR DESCRIPTION
ibc-go [8.0](https://github.com/cosmos/ibc-go/releases/tag/v8.0.0) added length validation that an address is a 2048 byte string or smaller - before that there was no maximum length. Make the faucet's isValidAddress function match it.

https://github.com/cosmos/ibc-go/blob/904047fc783f43ab87e3121c2c0c47ef7a6b075e/modules/apps/transfer/types/msgs.go#L16

https://github.com/cosmos/ibc-go/issues/4859#issuecomment-1761545047