### PR TITLE
Fix `decodeCommit` to allow decoding height 0 commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to
 
 - @cosmjs/faucet: `isValidAddress` now accepts addresses up to 128 bytes (e.g.
   for Penumbra). ([#1674])
+- @cosmjs/tendermint-rpc: Fix `decodeCommit` to allow decoding height 0 commits
+  with block hash set but empty signatures. ([#1590])
 
+[#1590]: https://github.com/cosmos/cosmjs/issues/1590
 [#1674]: https://github.com/cosmos/cosmjs/pull/1674
 
 ### Added

--- a/packages/tendermint-rpc/src/comet38/adaptor/responses.spec.ts
+++ b/packages/tendermint-rpc/src/comet38/adaptor/responses.spec.ts
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { fromBase64, fromHex } from "@cosmjs/encoding";
 
-import { decodeEvent, decodeValidatorGenesis, decodeValidatorInfo, decodeValidatorUpdate } from "./responses";
+import {
+  decodeCommit,
+  decodeEvent,
+  decodeValidatorGenesis,
+  decodeValidatorInfo,
+  decodeValidatorUpdate,
+} from "./responses";
 
 describe("Responses", () => {
   describe("decodeEvent", () => {
@@ -27,6 +33,36 @@ describe("Responses", () => {
       });
       expect(event.type).toEqual("cosmos.module.EmittedEvent");
       expect(event.attributes).toEqual([]);
+    });
+  });
+
+  describe("decodeCommit", () => {
+    it("works for commit at height 0", () => {
+      // See https://github.com/cosmos/cosmjs/issues/1590
+      const data = {
+        height: "0",
+        round: 0,
+        block_id: {
+          hash: "617E8F71CC8D555B0D30D2628C919C0DB20F9AFA07E3AA547DF3CBB999B9B33C",
+          parts: {
+            total: 1,
+            hash: "617E8F71CC8D555B0D30D2628C919C0DB20F9AFA07E3AA547DF3CBB999B9B33C",
+          },
+        },
+        signatures: null,
+      };
+      expect(decodeCommit(data)).toEqual({
+        height: 0,
+        round: 0,
+        blockId: {
+          hash: fromHex("617E8F71CC8D555B0D30D2628C919C0DB20F9AFA07E3AA547DF3CBB999B9B33C"),
+          parts: {
+            total: 1,
+            hash: fromHex("617E8F71CC8D555B0D30D2628C919C0DB20F9AFA07E3AA547DF3CBB999B9B33C"),
+          },
+        },
+        signatures: [],
+      });
     });
   });
 

--- a/packages/tendermint-rpc/src/comet38/adaptor/responses.ts
+++ b/packages/tendermint-rpc/src/comet38/adaptor/responses.ts
@@ -477,16 +477,16 @@ function decodeCommitSignature(data: RpcSignature): CommitSignature {
 interface RpcCommit {
   readonly block_id: RpcBlockId;
   readonly height: string;
-  readonly round: string;
-  readonly signatures: readonly RpcSignature[];
+  readonly round: string | number; // Seems to be number now (https://github.com/cosmos/cosmjs/issues/1590)
+  readonly signatures: readonly RpcSignature[] | null;
 }
 
-function decodeCommit(data: RpcCommit): responses.Commit {
+export function decodeCommit(data: RpcCommit): responses.Commit {
   return {
     blockId: decodeBlockId(assertObject(data.block_id)),
     height: apiToSmallInt(assertNotEmpty(data.height)),
     round: apiToSmallInt(data.round),
-    signatures: assertArray(data.signatures).map(decodeCommitSignature),
+    signatures: data.signatures ? assertArray(data.signatures).map(decodeCommitSignature) : [],
   };
 }
 


### PR DESCRIPTION
Closes #1590
