### PR TITLE
Fix broken links in TEST_VECTORS.md

### DIFF
--- a/packages/proto-signing/TEST_VECTORS.md
+++ b/packages/proto-signing/TEST_VECTORS.md
@@ -11,10 +11,10 @@ my branch (which can be rebased).
 ## Setup
 
 Test vectors are generated using those additions:
-https://github.com/CosmWasm/cosmos-sdk/pull/58
+https://github.com/cosmos/cosmos-sdk/pull/58
 
 ```
-git clone https://github.com/CosmWasm/cosmos-sdk.git
+git clone https://github.com/cosmos/cosmos-sdk.git
 cd cosmos-sdk
 git checkout cosmjs-test-vectors-v2
 


### PR DESCRIPTION
Line 14:
Old: https://github.com/CosmWasm/cosmos-sdk/pull/58
New: https://github.com/cosmos/cosmos-sdk/pull/58
Line 17:
Old: git clone https://github.com/CosmWasm/cosmos-sdk.git
New: git clone https://github.com/cosmos/cosmos-sdk.git

The old links in TEST_VECTORS.md were 404 errors. Updated to correct paths that work properly.