### PR TITLE
Fix broken link to MsgDelegate documentation in staking aminomessages

### DIFF
--- a/packages/stargate/src/modules/staking/aminomessages.ts
+++ b/packages/stargate/src/modules/staking/aminomessages.ts
@@ -93,7 +93,7 @@ export function isAminoMsgEditValidator(msg: AminoMsg): msg is AminoMsgEditValid
 /**
  * Performs a delegation from a delegate to a validator.
  *
- * @see https://docs.cosmos.network/master/modules/staking/03_messages.html#msgdelegate
+ * @see https://docs.cosmos.network/main/build/modules/staking#msgdelegate
  */
 export interface AminoMsgDelegate extends AminoMsg {
   readonly type: "cosmos-sdk/MsgDelegate";


### PR DESCRIPTION
Replaced the outdated Cosmos SDK documentation link for MsgDelegate in aminomessages.ts with the current and correct URL:
https://docs.cosmos.network/main/build/modules/staking#msgdelegate
This ensures that users and developers are directed to the up-to-date reference for the MsgDelegate message.