### PR TITLE
Fix typos in coins and encoding utility comments

### DIFF
--- a/packages/amino/src/coins.ts
+++ b/packages/amino/src/coins.ts
@@ -12,7 +12,7 @@ export interface Coin {
  * you can use the number type here. This is the case for all typical Cosmos SDK
  * chains that use the default 6 decimals.
  *
- * In case you need to supportr larger values, use unsigned integer strings instead.
+ * In case you need to support larger values, use unsigned integer strings instead.
  */
 export function coin(amount: number | string, denom: string): Coin {
   let outAmount: string;

--- a/packages/amino/src/encoding.ts
+++ b/packages/amino/src/encoding.ts
@@ -91,7 +91,7 @@ export function decodeAminoPubkey(data: Uint8Array): Pubkey {
 
 /**
  * Decodes a bech32 pubkey to Amino binary, which is then decoded to a type/value object.
- * The bech32 prefix is ignored and discareded.
+ * The bech32 prefix is ignored and discarded.
  *
  * @param bechEncoded the bech32 encoded pubkey
  */


### PR DESCRIPTION
Resolved minor typos in the amino package:

- supportr → support in coins.ts

- discareded → discarded in encoding.ts

These corrections improve the accuracy and clarity of the code documentation.