### PR TITLE
feat(encoding): improve hex conversion performance

### DIFF
--- a/packages/encoding/src/hex.ts
+++ b/packages/encoding/src/hex.ts
@@ -1,3 +1,5 @@
+// Helper function needed to support environments that do not yet have
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/map
 function* map<T, U>(iterable: Iterable<T>, fn: (value: T) => U): IterableIterator<U> {
   for (const value of iterable) {
     yield fn(value);


### PR DESCRIPTION
Replace string concatenation in toHex() with Array.from().map().join() pattern for better performance with large arrays. This approach avoids creating intermediate string objects during concatenation, resulting in better memory usage and execution speed, especially when processing large byte arrays