### PR TITLE
remove bn.js

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -3576,12 +3576,10 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@cosmjs/math", "workspace:packages/math"],\
           ["@istanbuljs/nyc-config-typescript", "virtual:4f1584ad4aba8733a24be7c8aebbffafef25607f2d00f4b314cf96717145c692763628a31c2b85d4686fbb091ff21ebffa3cc337399c042c19a32b9bdb786464#npm:1.0.1"],\
-          ["@types/bn.js", "npm:5.1.0"],\
           ["@types/jasmine", "npm:4.6.1"],\
           ["@types/karma-firefox-launcher", "npm:2.1.0"],\
           ["@types/karma-jasmine", "npm:4.0.2"],\
           ["@types/karma-jasmine-html-reporter", "npm:1.5.1"],\
-          ["bn.js", "npm:5.2.0"],\
           ["buffer", "npm:6.0.3"],\
           ["eslint", "npm:8.57.1"],\
           ["glob", "npm:11.0.3"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -482,10 +482,6 @@ const RAW_RUNTIME_STATE =
       "npm:1.3.0"\
     ],\
     [\
-      "@types/bn.js",\
-      "npm:5.1.0"\
-    ],\
-    [\
       "@types/body-parser",\
       "npm:1.19.0"\
     ],\
@@ -892,10 +888,6 @@ const RAW_RUNTIME_STATE =
     [\
       "bl",\
       "npm:4.1.0"\
-    ],\
-    [\
-      "bn.js",\
-      "npm:5.2.0"\
     ],\
     [\
       "body-parser",\
@@ -3369,14 +3361,12 @@ const RAW_RUNTIME_STATE =
           ["@istanbuljs/nyc-config-typescript", "virtual:4f1584ad4aba8733a24be7c8aebbffafef25607f2d00f4b314cf96717145c692763628a31c2b85d4686fbb091ff21ebffa3cc337399c042c19a32b9bdb786464#npm:1.0.1"],\
           ["@noble/curves", "npm:1.9.2"],\
           ["@noble/hashes", "npm:1.8.0"],\
-          ["@types/bn.js", "npm:5.1.0"],\
           ["@types/jasmine", "npm:4.6.1"],\
           ["@types/karma-firefox-launcher", "npm:2.1.0"],\
           ["@types/karma-jasmine", "npm:4.0.2"],\
           ["@types/karma-jasmine-html-reporter", "npm:1.5.1"],\
           ["@types/libsodium-wrappers-sumo", "npm:0.7.5"],\
           ["@types/node", "npm:22.10.6"],\
-          ["bn.js", "npm:5.2.0"],\
           ["buffer", "npm:6.0.3"],\
           ["eslint", "npm:8.57.1"],\
           ["glob", "npm:11.0.3"],\
@@ -4489,16 +4479,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/@types-base64-js-npm-1.3.0-9eadeb8d0d-6db015a703.zip/node_modules/@types/base64-js/",\
         "packageDependencies": [\
           ["@types/base64-js", "npm:1.3.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@types/bn.js", [\
-      ["npm:5.1.0", {\
-        "packageLocation": "./.yarn/cache/@types-bn.js-npm-5.1.0-4a0335ff4f-04c6705445.zip/node_modules/@types/bn.js/",\
-        "packageDependencies": [\
-          ["@types/bn.js", "npm:5.1.0"],\
-          ["@types/node", "npm:22.10.6"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -6468,15 +6448,6 @@ const RAW_RUNTIME_STATE =
           ["buffer", "npm:5.7.1"],\
           ["inherits", "npm:2.0.4"],\
           ["readable-stream", "npm:3.6.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["bn.js", [\
-      ["npm:5.2.0", {\
-        "packageLocation": "./.yarn/cache/bn.js-npm-5.2.0-11748c0b07-67e17b1934.zip/node_modules/bn.js/",\
-        "packageDependencies": [\
-          ["bn.js", "npm:5.2.0"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.yarn/cache/@types-bn.js-npm-5.1.0-4a0335ff4f-04c6705445.zip
+++ b/.yarn/cache/@types-bn.js-npm-5.1.0-4a0335ff4f-04c6705445.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b21444439e2316ffca00eae5dd7cca4b8bd1e6d6c93eba3cac6bc9a4d6320c2b
-size 14857

--- a/.yarn/cache/bn.js-npm-5.2.0-11748c0b07-67e17b1934.zip
+++ b/.yarn/cache/bn.js-npm-5.2.0-11748c0b07-67e17b1934.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:def3f0affc6832c980fc21a50f2fdd4116326cf2d60f85085b69917ce3fcbcd6
-size 101398

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -46,12 +46,10 @@
     "@cosmjs/utils": "workspace:^",
     "@noble/curves": "^1.9.2",
     "@noble/hashes": "^1",
-    "bn.js": "^5.2.0",
     "libsodium-wrappers-sumo": "^0.7.11"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@types/bn.js": "^5",
     "@types/jasmine": "^4",
     "@types/karma-firefox-launcher": "^2",
     "@types/karma-jasmine": "^4",

--- a/packages/crypto/src/slip10.ts
+++ b/packages/crypto/src/slip10.ts
@@ -1,8 +1,6 @@
-import { toAscii, toHex } from "@cosmjs/encoding";
+import { fromHex, toAscii, toHex } from "@cosmjs/encoding";
 import { Uint32, Uint53 } from "@cosmjs/math";
 import { secp256k1 } from "@noble/curves/secp256k1";
-// eslint-disable-next-line @typescript-eslint/naming-convention
-import BN from "bn.js";
 
 import { Hmac } from "./hmac";
 import { Sha512 } from "./sha";
@@ -24,6 +22,12 @@ export enum Slip10Curve {
 
 function bytesToUnsignedBigInt(a: Uint8Array): bigint {
   return BigInt("0x" + toHex(a));
+}
+
+function intTo32be(n: bigint): Uint8Array {
+  // 32 bytes is 64 hexadecimal characters
+  const hex = n.toString(16).padStart(64, "0");
+  return fromHex(hex);
 }
 
 /**
@@ -174,9 +178,9 @@ export class Slip10 {
     }
 
     // step 5
-    const n = this.n(curve);
-    const returnChildKeyAsNumber = new BN(il).add(new BN(parentPrivkey)).mod(n);
-    const returnChildKey = Uint8Array.from(returnChildKeyAsNumber.toArray("be", 32));
+    const n: bigint = this.n(curve);
+    const returnChildKeyAsNumber = (bytesToUnsignedBigInt(il) + bytesToUnsignedBigInt(parentPrivkey)) % n;
+    const returnChildKey = intTo32be(returnChildKeyAsNumber);
 
     // step 6
     if (this.isGteN(curve, il) || this.isZero(returnChildKey)) {
@@ -198,14 +202,14 @@ export class Slip10 {
   }
 
   private static isGteN(curve: Slip10Curve, privkey: Uint8Array): boolean {
-    const keyAsNumber = new BN(privkey);
-    return keyAsNumber.gte(this.n(curve));
+    const keyAsNumber: bigint = bytesToUnsignedBigInt(privkey);
+    return keyAsNumber >= this.n(curve);
   }
 
-  private static n(curve: Slip10Curve): BN {
+  private static n(curve: Slip10Curve): bigint {
     switch (curve) {
       case Slip10Curve.Secp256k1:
-        return new BN("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16);
+        return 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141n;
       default:
         throw new Error("curve not supported");
     }

--- a/packages/crypto/src/slip10.ts
+++ b/packages/crypto/src/slip10.ts
@@ -181,7 +181,7 @@ export class Slip10 {
     }
 
     // step 5
-    const n: bigint = this.n(curve);
+    const n = this.n(curve);
     const returnChildKeyAsNumber = (bytesToUnsignedBigInt(il) + bytesToUnsignedBigInt(parentPrivkey)) % n;
     const returnChildKey = intTo32be(returnChildKeyAsNumber);
 
@@ -205,7 +205,7 @@ export class Slip10 {
   }
 
   private static isGteN(curve: Slip10Curve, privkey: Uint8Array): boolean {
-    const keyAsNumber: bigint = bytesToUnsignedBigInt(privkey);
+    const keyAsNumber = bytesToUnsignedBigInt(privkey);
     return keyAsNumber >= this.n(curve);
   }
 

--- a/packages/crypto/src/slip10.ts
+++ b/packages/crypto/src/slip10.ts
@@ -1,5 +1,6 @@
 import { fromHex, toAscii, toHex } from "@cosmjs/encoding";
 import { Uint32, Uint53 } from "@cosmjs/math";
+import { assert } from "@cosmjs/utils";
 import { secp256k1 } from "@noble/curves/secp256k1";
 
 import { Hmac } from "./hmac";
@@ -25,6 +26,8 @@ function bytesToUnsignedBigInt(a: Uint8Array): bigint {
 }
 
 function intTo32be(n: bigint): Uint8Array {
+  assert(n >= 0n);
+  assert(n < 2n ** (32n * 8n));
   // 32 bytes is 64 hexadecimal characters
   const hex = n.toString(16).padStart(64, "0");
   return fromHex(hex);

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -39,12 +39,8 @@
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "pack-web": "yarn build-or-skip && webpack --mode development --config webpack.web.config.js"
   },
-  "dependencies": {
-    "bn.js": "^5.2.0"
-  },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@types/bn.js": "^5",
     "@types/jasmine": "^4",
     "@types/karma-firefox-launcher": "^2",
     "@types/karma-jasmine": "^4",

--- a/packages/math/src/decimal.ts
+++ b/packages/math/src/decimal.ts
@@ -91,7 +91,10 @@ export class Decimal {
 
   public static compare(a: Decimal, b: Decimal): number {
     if (a.fractionalDigits !== b.fractionalDigits) throw new Error("Fractional digits do not match");
-    return Math.sign(Number(a.data.atomics - b.data.atomics));
+    const difference = a.data.atomics - b.data.atomics;
+    if (difference < 0n) return -1;
+    if (difference > 0n) return 1;
+    return 0;
   }
 
   public get atomics(): string {

--- a/packages/math/src/integers.ts
+++ b/packages/math/src/integers.ts
@@ -272,10 +272,10 @@ export class Uint64 implements Integer, WithByteConverters {
   }
 
   public toNumber(): number {
-    const num = Number(this.data);
-    if (!Number.isSafeInteger(num)) {
+    if (this.data > BigInt(Number.MAX_SAFE_INTEGER)) {
       throw new Error("number can only safely store up to 53 bits");
     }
+    const num = Number(this.data);
     return num;
   }
 }

--- a/packages/math/src/integers.ts
+++ b/packages/math/src/integers.ts
@@ -274,7 +274,7 @@ export class Uint64 implements Integer, WithByteConverters {
   public toNumber(): number {
     const num = Number(this.data);
     if (!Number.isSafeInteger(num)) {
-      throw new Error("Not safe integer");
+      throw new Error("number can only safely store up to 53 bits");
     }
     return num;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,14 +326,12 @@ __metadata:
     "@istanbuljs/nyc-config-typescript": "npm:^1.0.1"
     "@noble/curves": "npm:^1.9.2"
     "@noble/hashes": "npm:^1"
-    "@types/bn.js": "npm:^5"
     "@types/jasmine": "npm:^4"
     "@types/karma-firefox-launcher": "npm:^2"
     "@types/karma-jasmine": "npm:^4"
     "@types/karma-jasmine-html-reporter": "npm:^1"
     "@types/libsodium-wrappers-sumo": "npm:^0.7.5"
     "@types/node": "npm:*"
-    bn.js: "npm:^5.2.0"
     buffer: "npm:^6.0.3"
     eslint: "npm:^8.57.1"
     glob: "npm:^11"
@@ -1297,15 +1295,6 @@ __metadata:
   version: 1.3.0
   resolution: "@types/base64-js@npm:1.3.0"
   checksum: 10c0/6db015a7034508942413d72881df80b6c6af7186fcbf1ac39881a802daaef12dbb43bd3710ce83ff3f89b34491a5f552c0cd9012779a09bda249c5fd39590b6b
-  languageName: node
-  linkType: hard
-
-"@types/bn.js@npm:^5":
-  version: 5.1.0
-  resolution: "@types/bn.js@npm:5.1.0"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/04c6705445f8588ca54bb1e28bee6a1e3e97fa87551cde45b6f7e1d856d394ae0d36d3c75f11388062562dc0a6f4b4e0d5282ccfbe463d472589f9d1cc95ebd5
   languageName: node
   linkType: hard
 
@@ -2308,13 +2297,6 @@ __metadata:
     inherits: "npm:^2.0.4"
     readable-stream: "npm:^3.4.0"
   checksum: 10c0/02847e1d2cb089c9dc6958add42e3cdeaf07d13f575973963335ac0fdece563a50ac770ac4c8fa06492d2dd276f6cc3b7f08c7cd9c7a7ad0f8d388b2a28def5f
-  languageName: node
-  linkType: hard
-
-"bn.js@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "bn.js@npm:5.2.0"
-  checksum: 10c0/67e17b1934d9c7a73aed9b89222dc8c1c8e3aff46cca6609b8c2ab04fa22c6b8db42c7774b039d09fa63136d8866b777ab88af0d64d8ea3839a94e69193a6b13
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,12 +523,10 @@ __metadata:
   resolution: "@cosmjs/math@workspace:packages/math"
   dependencies:
     "@istanbuljs/nyc-config-typescript": "npm:^1.0.1"
-    "@types/bn.js": "npm:^5"
     "@types/jasmine": "npm:^4"
     "@types/karma-firefox-launcher": "npm:^2"
     "@types/karma-jasmine": "npm:^4"
     "@types/karma-jasmine-html-reporter": "npm:^1"
-    bn.js: "npm:^5.2.0"
     buffer: "npm:^6.0.3"
     eslint: "npm:^8.57.1"
     glob: "npm:^11"


### PR DESCRIPTION
Closes #1711

`bigint` doesn't seem to actually be missing any math?

The new byte array convesion helper function from #1698 `bytesToUnsignedBigInt()` really helps though.