### PR TITLE
simplify ancient class Random

### DIFF
--- a/packages/crypto/src/random.ts
+++ b/packages/crypto/src/random.ts
@@ -1,27 +1,10 @@
-declare const window: any;
-declare const self: any;
-
 export class Random {
   /**
    * Returns `count` cryptographically secure random bytes
    */
   public static getBytes(count: number): Uint8Array {
-    try {
-      const globalObject = typeof window === "object" ? window : self;
-      const cryptoApi =
-        typeof globalObject.crypto !== "undefined" ? globalObject.crypto : globalObject.msCrypto;
-
-      const out = new Uint8Array(count);
-      cryptoApi.getRandomValues(out);
-      return out;
-    } catch {
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const crypto = require("crypto");
-        return new Uint8Array([...crypto.randomBytes(count)]);
-      } catch {
-        throw new Error("No secure random number generator found");
-      }
-    }
+    const out = new Uint8Array(count);
+    globalThis.crypto.getRandomValues(out);
+    return out;
   }
 }


### PR DESCRIPTION
Node.js 15 implements `getRandomValues()`.

https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues

`globalThis` has existed since Node.js 12.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis

Node.js 10 was EOL in 2021 #811 and v14 in #1421

One-third of #1724