### PR TITLE
Modernize child_process import in reconnecting socket test

### DIFF
--- a/packages/socket/src/reconnectingsocket.spec.ts
+++ b/packages/socket/src/reconnectingsocket.spec.ts
@@ -3,7 +3,7 @@ import assert from "assert";
 import { ReconnectingSocket } from "./reconnectingsocket";
 
 /** @see https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback */
-type Exec = (command: string, callback: (error: null | (Error & { readonly code: number })) => void) => void;
+type Exec = (command: string, callback: (error: null | (Error & { readonly code?: number })) => void) => void;
 
 let exec: Exec | undefined;
 let childProcessAvailable: boolean;

--- a/packages/socket/src/reconnectingsocket.spec.ts
+++ b/packages/socket/src/reconnectingsocket.spec.ts
@@ -1,31 +1,13 @@
-import assert from "assert";
-
 import { ReconnectingSocket } from "./reconnectingsocket";
 
 /** @see https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback */
 type Exec = (command: string, callback: (error: null | (Error & { readonly code?: number })) => void) => void;
 
-let exec: Exec | undefined;
-let childProcessAvailable: boolean;
-
-try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  exec = require("child_process").exec;
-  assert.strict(typeof exec === "function");
-  childProcessAvailable = true;
-} catch {
-  childProcessAvailable = false;
-}
+const getExec = async (): Promise<Exec | undefined> => (await import("child_process")).exec;
 
 function pendingWithoutSocketServer(): void {
   if (!process.env.SOCKETSERVER_ENABLED) {
     pending("Set SOCKETSERVER_ENABLED to enable socket tests");
-  }
-}
-
-function pendingWithoutChildProcess(): void {
-  if (!childProcessAvailable) {
-    pending("Run test in an environment which supports child processes to enable socket tests");
   }
 }
 
@@ -104,10 +86,15 @@ describe("ReconnectingSocket", () => {
         fail = reject;
       });
 
-      pendingWithoutChildProcess();
+      const exec = await getExec();
+      if (exec === undefined) {
+        pending("Run test in an environment which supports child processes to enable socket tests");
+        return;
+      }
+
       pendingWithoutSocketServer();
 
-      exec!(stopServerCmd, (stopError) => {
+      exec(stopServerCmd, (stopError) => {
         if (stopError && stopError.code !== codePkillNoProcessesMatched) {
           fail(stopError);
         }
@@ -134,7 +121,7 @@ describe("ReconnectingSocket", () => {
 
         setTimeout(
           () =>
-            exec!(startServerCmd, (startError) => {
+            exec(startServerCmd, (startError) => {
               if (startError) {
                 fail(startError);
               }
@@ -153,7 +140,12 @@ describe("ReconnectingSocket", () => {
         fail = reject;
       });
 
-      pendingWithoutChildProcess();
+      const exec = await getExec();
+      if (exec === undefined) {
+        pending("Run test in an environment which supports child processes to enable socket tests");
+        return;
+      }
+
       pendingWithoutSocketServer();
 
       const socket = new ReconnectingSocket(socketServerUrl);
@@ -178,7 +170,7 @@ describe("ReconnectingSocket", () => {
 
       setTimeout(
         () =>
-          exec!(stopServerCmd, (stopError) => {
+          exec(stopServerCmd, (stopError) => {
             if (stopError && stopError.code !== codePkillNoProcessesMatched) {
               fail(stopError);
             }
@@ -193,7 +185,7 @@ describe("ReconnectingSocket", () => {
 
               setTimeout(
                 () =>
-                  exec!(startServerCmd, (startError) => {
+                  exec(startServerCmd, (startError) => {
                     if (startError) {
                       fail(startError);
                     }


### PR DESCRIPTION
One-third of #1724. Closes #1724

Looks like this test code was inherited from #246

https://github.com/webpack/webpack/releases/v5.92.0

webpack added a feature that adds `node:` prefixes "in runtime code," but still compile-time rejects it if it's already present in the code, and the target is a browser. Even if it's a dynamic import, which can fail.