### PR TITLE
Add packages/*/dist/ to eslint ignore patterns

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@
 // https://eslint.org/docs/v8.x/use/configure/configuration-files#cascading-and-hierarchy
 
 module.exports = {
-  ignorePatterns: ["packages/*/build/", "packages/*/docs/", "packages/*/examples/"],
+  ignorePatterns: ["packages/*/build/", "packages/*/dist/", "packages/*/docs/", "packages/*/examples/"],
   root: true,
   env: {
     es6: true,


### PR DESCRIPTION
In https://github.com/cosmos/cosmjs/pull/1705 we missed the dist directory which is created in browser test builds (by webpack). If you have one of those dist folders in a local checkout, the lint will take forever.