### PR TITLE
enable strict lints

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,7 +89,6 @@ export default [
       "@typescript-eslint/no-deprecated": "off",
       "@typescript-eslint/no-extraneous-class": "off",
       "@typescript-eslint/no-unnecessary-condition": "off",
-      "@typescript-eslint/restrict-plus-operands": "off",
       "@typescript-eslint/use-unknown-in-catch-callback-variable": "off",
 
       "@typescript-eslint/array-type": [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -79,11 +79,22 @@ export default [
     rules: {
       "no-shadow": "off",
       "no-unused-vars": "off",
-      ...typescriptEslint.configs["flat/recommended-type-checked"].reduce(
+      ...typescriptEslint.configs["flat/strict-type-checked"].reduce(
         (obj, c) => Object.assign(obj, c.rules),
         {},
       ),
       ...importt.flatConfigs.typescript.rules,
+
+      // lints from 'strict-type-checked' config
+      "@typescript-eslint/no-confusing-void-expression": "off",
+      "@typescript-eslint/no-deprecated": "off",
+      "@typescript-eslint/no-extraneous-class": "off",
+      "@typescript-eslint/no-unnecessary-condition": "off",
+      "@typescript-eslint/no-unnecessary-type-parameters": "off",
+      "@typescript-eslint/prefer-return-this-type": "off",
+      "@typescript-eslint/restrict-plus-operands": "off",
+      "@typescript-eslint/use-unknown-in-catch-callback-variable": "off",
+
       "@typescript-eslint/array-type": [
         "warn",
         {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -102,6 +102,8 @@ export default [
 
       "@typescript-eslint/explicit-member-accessibility": "warn",
 
+      "@typescript-eslint/explicit-module-boundary-types": "warn",
+
       "@typescript-eslint/naming-convention": [
         "warn",
         {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,7 +89,6 @@ export default [
       "@typescript-eslint/no-deprecated": "off",
       "@typescript-eslint/no-extraneous-class": "off",
       "@typescript-eslint/no-unnecessary-condition": "off",
-      "@typescript-eslint/no-unnecessary-type-parameters": "off",
       "@typescript-eslint/restrict-plus-operands": "off",
       "@typescript-eslint/use-unknown-in-catch-callback-variable": "off",
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -91,7 +91,6 @@ export default [
       "@typescript-eslint/no-extraneous-class": "off",
       "@typescript-eslint/no-unnecessary-condition": "off",
       "@typescript-eslint/no-unnecessary-type-parameters": "off",
-      "@typescript-eslint/prefer-return-this-type": "off",
       "@typescript-eslint/restrict-plus-operands": "off",
       "@typescript-eslint/use-unknown-in-catch-callback-variable": "off",
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -86,7 +86,6 @@ export default [
       ...importt.flatConfigs.typescript.rules,
 
       // lints from 'strict-type-checked' config
-      "@typescript-eslint/no-confusing-void-expression": "off",
       "@typescript-eslint/no-deprecated": "off",
       "@typescript-eslint/no-extraneous-class": "off",
       "@typescript-eslint/no-unnecessary-condition": "off",

--- a/packages/cosmwasm-stargate/src/modules/wasm/aminomessages.ts
+++ b/packages/cosmwasm-stargate/src/modules/wasm/aminomessages.ts
@@ -28,7 +28,7 @@ export function accessTypeFromString(str: string): AccessType {
   }
 }
 
-export function accessTypeToString(object: any): string {
+export function accessTypeToString(object: AccessType): string {
   switch (object) {
     case AccessType.ACCESS_TYPE_UNSPECIFIED:
       return "Unspecified";

--- a/packages/cosmwasm-stargate/src/testutils.spec.ts
+++ b/packages/cosmwasm-stargate/src/testutils.spec.ts
@@ -151,7 +151,8 @@ export function wasmdEnabled(): boolean {
 
 export function pendingWithoutWasmd(): void {
   if (!wasmdEnabled()) {
-    return pending("Set WASMD_ENABLED to enable Wasmd-based tests");
+    pending("Set WASMD_ENABLED to enable Wasmd-based tests");
+    return;
   }
 }
 

--- a/packages/crypto/src/hmac.ts
+++ b/packages/crypto/src/hmac.ts
@@ -37,7 +37,7 @@ export class Hmac<H extends HashFunction> implements HashFunction {
     this.update(this.iKeyPad);
   }
 
-  public update(data: Uint8Array): Hmac<H> {
+  public update(data: Uint8Array): this {
     this.messageHasher.update(data);
     return this;
   }

--- a/packages/crypto/src/keccak.ts
+++ b/packages/crypto/src/keccak.ts
@@ -14,7 +14,7 @@ export class Keccak256 implements HashFunction {
     }
   }
 
-  public update(data: Uint8Array): Keccak256 {
+  public update(data: Uint8Array): this {
     this.impl.update(toRealUint8Array(data));
     return this;
   }

--- a/packages/crypto/src/libsodium.spec.ts
+++ b/packages/crypto/src/libsodium.spec.ts
@@ -16,18 +16,18 @@ describe("Libsodium", () => {
       const salt = toAscii("ABCDEFGHIJKLMNOP");
 
       // echo -n "123" | ./argon2 ABCDEFGHIJKLMNOP -id -v 13 -k 1024 -t 5
-      await Argon2id.execute("123", salt, options).then((result) =>
-        expect(result).toEqual(fromHex("3c5d010180ba0cf5b6b858cba23b318e42d33088983c404598599c3b029ecac6")),
-      );
-      await Argon2id.execute("!'§$%&/()", salt, options).then((result) =>
-        expect(result).toEqual(fromHex("b0268bd63015c3d8f866f9be385507b466a9bfc75f271c2c1e97c00bf53224ba")),
-      );
-      await Argon2id.execute("ö", salt, options).then((result) =>
-        expect(result).toEqual(fromHex("b113fc7863dbc87b7d1366c3b468d3864a2473ce46e90ed3641fff87ada561f7")),
-      );
-      await Argon2id.execute("😎", salt, options).then((result) =>
-        expect(result).toEqual(fromHex("dc92db2a69a5607a75472e1581ac0851292ed9a2606f1000f62fa2efc97964e0")),
-      );
+      await Argon2id.execute("123", salt, options).then((result) => {
+        expect(result).toEqual(fromHex("3c5d010180ba0cf5b6b858cba23b318e42d33088983c404598599c3b029ecac6"));
+      });
+      await Argon2id.execute("!'§$%&/()", salt, options).then((result) => {
+        expect(result).toEqual(fromHex("b0268bd63015c3d8f866f9be385507b466a9bfc75f271c2c1e97c00bf53224ba"));
+      });
+      await Argon2id.execute("ö", salt, options).then((result) => {
+        expect(result).toEqual(fromHex("b113fc7863dbc87b7d1366c3b468d3864a2473ce46e90ed3641fff87ada561f7"));
+      });
+      await Argon2id.execute("😎", salt, options).then((result) => {
+        expect(result).toEqual(fromHex("dc92db2a69a5607a75472e1581ac0851292ed9a2606f1000f62fa2efc97964e0"));
+      });
     });
 
     it("works for 8 MiB memory and opsLimit = 2", async () => {
@@ -39,18 +39,18 @@ describe("Libsodium", () => {
       const salt = toAscii("ABCDEFGHIJKLMNOP");
 
       // echo -n "123" | ./argon2 ABCDEFGHIJKLMNOP -id -v 13 -k 8192 -t 2
-      await Argon2id.execute("123", salt, options).then((result) =>
-        expect(result).toEqual(fromHex("3ee950488d26ce691657b1d753f562139857b61a58f234d6cb0ce84c4cc27328")),
-      );
-      await Argon2id.execute("!'§$%&/()", salt, options).then((result) =>
-        expect(result).toEqual(fromHex("ab410498b44942a28f9d0dde72f0398edf104021ee41bb80412464975817a8a1")),
-      );
-      await Argon2id.execute("ö", salt, options).then((result) =>
-        expect(result).toEqual(fromHex("f80c502bc3fe7b191f6e7e06359955d5dbd23f532548b7058ecbcf77a58e683d")),
-      );
-      await Argon2id.execute("😎", salt, options).then((result) =>
-        expect(result).toEqual(fromHex("474d9445596d2600ba3dc9bbe87d21ed4879e2445cafb10fcb69c5c3ab8ecbc7")),
-      );
+      await Argon2id.execute("123", salt, options).then((result) => {
+        expect(result).toEqual(fromHex("3ee950488d26ce691657b1d753f562139857b61a58f234d6cb0ce84c4cc27328"));
+      });
+      await Argon2id.execute("!'§$%&/()", salt, options).then((result) => {
+        expect(result).toEqual(fromHex("ab410498b44942a28f9d0dde72f0398edf104021ee41bb80412464975817a8a1"));
+      });
+      await Argon2id.execute("ö", salt, options).then((result) => {
+        expect(result).toEqual(fromHex("f80c502bc3fe7b191f6e7e06359955d5dbd23f532548b7058ecbcf77a58e683d"));
+      });
+      await Argon2id.execute("😎", salt, options).then((result) => {
+        expect(result).toEqual(fromHex("474d9445596d2600ba3dc9bbe87d21ed4879e2445cafb10fcb69c5c3ab8ecbc7"));
+      });
     });
 
     it("works for 10 MiB memory and opsLimit = 1", async () => {
@@ -62,18 +62,18 @@ describe("Libsodium", () => {
       const salt = toAscii("ABCDEFGHIJKLMNOP");
 
       // echo -n "123" | ./argon2 ABCDEFGHIJKLMNOP -id -v 13 -k 10240 -t 1
-      await Argon2id.execute("123", salt, options).then((result) =>
-        expect(result).toEqual(fromHex("f1832edbd41c209546eafd01f3aae28390de39bc13ff38981c4fc0c1ceaa05e3")),
-      );
-      await Argon2id.execute("!'§$%&/()", salt, options).then((result) =>
-        expect(result).toEqual(fromHex("30c74f405d148fd5c882a0f4238aad9ed85ef255adc102411d22736d68f76f76")),
-      );
-      await Argon2id.execute("ö", salt, options).then((result) =>
-        expect(result).toEqual(fromHex("b80a62f11e7a058194a8ddd80d341c47e0f3b6c41c72ee15b7926788e9963e8f")),
-      );
-      await Argon2id.execute("😎", salt, options).then((result) =>
-        expect(result).toEqual(fromHex("b868aa1875de2edc57bc22de1fc75f9d19f451067c529565f73c61958088b5e9")),
-      );
+      await Argon2id.execute("123", salt, options).then((result) => {
+        expect(result).toEqual(fromHex("f1832edbd41c209546eafd01f3aae28390de39bc13ff38981c4fc0c1ceaa05e3"));
+      });
+      await Argon2id.execute("!'§$%&/()", salt, options).then((result) => {
+        expect(result).toEqual(fromHex("30c74f405d148fd5c882a0f4238aad9ed85ef255adc102411d22736d68f76f76"));
+      });
+      await Argon2id.execute("ö", salt, options).then((result) => {
+        expect(result).toEqual(fromHex("b80a62f11e7a058194a8ddd80d341c47e0f3b6c41c72ee15b7926788e9963e8f"));
+      });
+      await Argon2id.execute("😎", salt, options).then((result) => {
+        expect(result).toEqual(fromHex("b868aa1875de2edc57bc22de1fc75f9d19f451067c529565f73c61958088b5e9"));
+      });
     });
 
     it("works for different output lengths", async () => {
@@ -112,9 +112,9 @@ describe("Libsodium", () => {
           opsLimit: 5,
           memLimitKib: 1024,
         };
-        await Argon2id.execute("123", salt, options).then((result) =>
-          expect(result).toEqual(fromHex(data.get(length)!)),
-        );
+        await Argon2id.execute("123", salt, options).then((result) => {
+          expect(result).toEqual(fromHex(data.get(length)!));
+        });
       }
     });
 
@@ -128,24 +128,40 @@ describe("Libsodium", () => {
 
       // 8 bytes
       await Argon2id.execute(password, fromHex("aabbccddeeff0011"), options)
-        .then(() => fail("Argon2id with invalid salt length must not resolve"))
-        .catch((e) => expect(e).toMatch(/invalid salt length/));
+        .then(() => {
+          fail("Argon2id with invalid salt length must not resolve");
+        })
+        .catch((e) => {
+          expect(e).toMatch(/invalid salt length/);
+        });
       // 15 bytes
       await Argon2id.execute(password, fromHex("aabbccddeeff001122334455667788"), options)
-        .then(() => fail("Argon2id with invalid salt length must not resolve"))
-        .catch((e) => expect(e).toMatch(/invalid salt length/));
+        .then(() => {
+          fail("Argon2id with invalid salt length must not resolve");
+        })
+        .catch((e) => {
+          expect(e).toMatch(/invalid salt length/);
+        });
       // 17 bytes
       await Argon2id.execute(password, fromHex("aabbccddeeff00112233445566778899aa"), options)
-        .then(() => fail("Argon2id with invalid salt length must not resolve"))
-        .catch((e) => expect(e).toMatch(/invalid salt length/));
+        .then(() => {
+          fail("Argon2id with invalid salt length must not resolve");
+        })
+        .catch((e) => {
+          expect(e).toMatch(/invalid salt length/);
+        });
       // 32 bytes
       await Argon2id.execute(
         password,
         fromHex("aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"),
         options,
       )
-        .then(() => fail("Argon2id with invalid salt length must not resolve"))
-        .catch((e) => expect(e).toMatch(/invalid salt length/));
+        .then(() => {
+          fail("Argon2id with invalid salt length must not resolve");
+        })
+        .catch((e) => {
+          expect(e).toMatch(/invalid salt length/);
+        });
     });
   });
 
@@ -406,22 +422,34 @@ describe("Libsodium", () => {
         // empty
         const key = fromHex("");
         await Xchacha20poly1305Ietf.encrypt(message, key, nonce)
-          .then(() => fail("encryption must not succeed"))
-          .catch((error) => expect(error).toMatch(/invalid key length/));
+          .then(() => {
+            fail("encryption must not succeed");
+          })
+          .catch((error) => {
+            expect(error).toMatch(/invalid key length/);
+          });
       }
       {
         // 31 bytes
         const key = fromHex("1324cdddc4b94e625bbabcac862c9429ba011e2184a1ccad60e7c3f6ff4916");
         await Xchacha20poly1305Ietf.encrypt(message, key, nonce)
-          .then(() => fail("encryption must not succeed"))
-          .catch((error) => expect(error).toMatch(/invalid key length/));
+          .then(() => {
+            fail("encryption must not succeed");
+          })
+          .catch((error) => {
+            expect(error).toMatch(/invalid key length/);
+          });
       }
       {
         // 33 bytes
         const key = fromHex("1324cdddc4b94e625bbabcac862c9429ba011e2184a1ccad60e7c3f6ff4916d8aa");
         await Xchacha20poly1305Ietf.encrypt(message, key, nonce)
-          .then(() => fail("encryption must not succeed"))
-          .catch((error) => expect(error).toMatch(/invalid key length/));
+          .then(() => {
+            fail("encryption must not succeed");
+          })
+          .catch((error) => {
+            expect(error).toMatch(/invalid key length/);
+          });
       }
       {
         // 64 bytes
@@ -429,8 +457,12 @@ describe("Libsodium", () => {
           "1324cdddc4b94e625bbabcac862c9429ba011e2184a1ccad60e7c3f6ff4916d81324cdddc4b94e625bbabcac862c9429ba011e2184a1ccad60e7c3f6ff4916d8",
         );
         await Xchacha20poly1305Ietf.encrypt(message, key, nonce)
-          .then(() => fail("encryption must not succeed"))
-          .catch((error) => expect(error).toMatch(/invalid key length/));
+          .then(() => {
+            fail("encryption must not succeed");
+          })
+          .catch((error) => {
+            expect(error).toMatch(/invalid key length/);
+          });
       }
     });
 
@@ -451,24 +483,36 @@ describe("Libsodium", () => {
         // corrupted ciphertext
         const corruptedCiphertext = ciphertext.map((x, i) => (i === 0 ? x ^ 0x01 : x));
         await Xchacha20poly1305Ietf.decrypt(corruptedCiphertext, key, nonce).then(
-          () => fail("promise must not resolve"),
-          (error) => expect(error.message).toMatch(/ciphertext cannot be decrypted using that key/i),
+          () => {
+            fail("promise must not resolve");
+          },
+          (error) => {
+            expect(error.message).toMatch(/ciphertext cannot be decrypted using that key/i);
+          },
         );
       }
       {
         // corrupted key
         const corruptedKey = key.map((x, i) => (i === 0 ? x ^ 0x01 : x));
         await Xchacha20poly1305Ietf.decrypt(ciphertext, corruptedKey, nonce).then(
-          () => fail("promise must not resolve"),
-          (error) => expect(error.message).toMatch(/ciphertext cannot be decrypted using that key/i),
+          () => {
+            fail("promise must not resolve");
+          },
+          (error) => {
+            expect(error.message).toMatch(/ciphertext cannot be decrypted using that key/i);
+          },
         );
       }
       {
         // corrupted nonce
         const corruptedNonce = nonce.map((x, i) => (i === 0 ? x ^ 0x01 : x));
         await Xchacha20poly1305Ietf.decrypt(ciphertext, key, corruptedNonce).then(
-          () => fail("promise must not resolve"),
-          (error) => expect(error.message).toMatch(/ciphertext cannot be decrypted using that key/i),
+          () => {
+            fail("promise must not resolve");
+          },
+          (error) => {
+            expect(error.message).toMatch(/ciphertext cannot be decrypted using that key/i);
+          },
         );
       }
     });

--- a/packages/crypto/src/pbkdf2.spec.ts
+++ b/packages/crypto/src/pbkdf2.spec.ts
@@ -123,7 +123,10 @@ describe("pbkdf2", () => {
   describe("pbkdf2Sha512Subtle", () => {
     it("works", async () => {
       const subtle = await getSubtle();
-      if (!subtle) return pending("Subtle is not available in this environment");
+      if (!subtle) {
+        pending("Subtle is not available in this environment");
+        return;
+      }
 
       {
         const { secret, salt, iterations, keylen, expected } = botanTest;

--- a/packages/crypto/src/pbkdf2.spec.ts
+++ b/packages/crypto/src/pbkdf2.spec.ts
@@ -123,7 +123,7 @@ describe("pbkdf2", () => {
   describe("pbkdf2Sha512Subtle", () => {
     it("works", async () => {
       const subtle = await getSubtle();
-      if (!subtle) pending("Subtle is not available in this environment");
+      if (!subtle) return pending("Subtle is not available in this environment");
 
       {
         const { secret, salt, iterations, keylen, expected } = botanTest;

--- a/packages/crypto/src/pbkdf2.ts
+++ b/packages/crypto/src/pbkdf2.ts
@@ -1,6 +1,6 @@
 import { assert } from "@cosmjs/utils";
 import { pbkdf2Async as noblePbkdf2Async } from "@noble/hashes/pbkdf2";
-import { sha512 as nobleSha512 } from "@noble/hashes/sha512";
+import { sha512 as nobleSha512 } from "@noble/hashes/sha2.js";
 
 export async function getSubtle(): Promise<typeof crypto.subtle | undefined> {
   // From Node.js 15 onwards, webcrypto is available in globalThis.

--- a/packages/crypto/src/pbkdf2.ts
+++ b/packages/crypto/src/pbkdf2.ts
@@ -2,7 +2,7 @@ import { assert } from "@cosmjs/utils";
 import { pbkdf2Async as noblePbkdf2Async } from "@noble/hashes/pbkdf2";
 import { sha512 as nobleSha512 } from "@noble/hashes/sha512";
 
-export async function getSubtle(): Promise<any | undefined> {
+export async function getSubtle(): Promise<typeof crypto.subtle | undefined> {
   // From Node.js 15 onwards, webcrypto is available in globalThis.
   // In version 15 and 16 this was stored under the webcrypto key.
   // With Node.js 17 it was moved to the same locations where browsers
@@ -11,7 +11,7 @@ export async function getSubtle(): Promise<any | undefined> {
   // causes issues with bundlers and does not increase compatibility.
 
   // Browsers and Node.js 17+
-  let subtle: any | undefined = (globalThis as any)?.crypto?.subtle;
+  let subtle: typeof crypto.subtle | undefined = (globalThis as any)?.crypto?.subtle;
   // Node.js 15+
   if (!subtle) subtle = (globalThis as any)?.crypto?.webcrypto?.subtle;
 
@@ -19,8 +19,7 @@ export async function getSubtle(): Promise<any | undefined> {
 }
 
 export async function pbkdf2Sha512Subtle(
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  subtle: any,
+  subtle: typeof crypto.subtle,
   secret: Uint8Array,
   salt: Uint8Array,
   iterations: number,
@@ -31,7 +30,7 @@ export async function pbkdf2Sha512Subtle(
   assert(typeof subtle.importKey === "function", "subtle.importKey is not a function");
   assert(typeof subtle.deriveBits === "function", "subtle.deriveBits is not a function");
 
-  return subtle.importKey("raw", secret, { name: "PBKDF2" }, false, ["deriveBits"]).then((key: Uint8Array) =>
+  return subtle.importKey("raw", secret, { name: "PBKDF2" }, false, ["deriveBits"]).then((key) =>
     subtle
       .deriveBits(
         {

--- a/packages/crypto/src/ripemd.ts
+++ b/packages/crypto/src/ripemd.ts
@@ -1,4 +1,4 @@
-import { ripemd160 as nobleRipemd160 } from "@noble/hashes/ripemd160";
+import { ripemd160 as nobleRipemd160 } from "@noble/hashes/legacy.js";
 
 import { HashFunction } from "./hash";
 import { toRealUint8Array } from "./utils";

--- a/packages/crypto/src/ripemd.ts
+++ b/packages/crypto/src/ripemd.ts
@@ -14,7 +14,7 @@ export class Ripemd160 implements HashFunction {
     }
   }
 
-  public update(data: Uint8Array): Ripemd160 {
+  public update(data: Uint8Array): this {
     this.impl.update(toRealUint8Array(data));
     return this;
   }

--- a/packages/crypto/src/secp256k1.spec.ts
+++ b/packages/crypto/src/secp256k1.spec.ts
@@ -69,22 +69,42 @@ describe("Secp256k1", () => {
 
     // too short and too long
     await Secp256k1.makeKeypair(fromHex("e4ade2a5232a7c6f37e7b854a774e25e6047ee7c6d63e8304ae04fa190bc17"))
-      .then(() => fail("promise must be rejected"))
-      .catch((error) => expect(error.message).toContain("not a valid secp256k1 private key"));
+      .then(() => {
+        fail("promise must be rejected");
+      })
+      .catch((error) => {
+        expect(error.message).toContain("not a valid secp256k1 private key");
+      });
     await Secp256k1.makeKeypair(fromHex("e4ade2a5232a7c6f37e7b854a774e25e6047ee7c6d63e8304ae04fa190bc1732aa"))
-      .then(() => fail("promise must be rejected"))
-      .catch((error) => expect(error.message).toContain("not a valid secp256k1 private key"));
+      .then(() => {
+        fail("promise must be rejected");
+      })
+      .catch((error) => {
+        expect(error.message).toContain("not a valid secp256k1 private key");
+      });
     // value out of range (too small)
     await Secp256k1.makeKeypair(fromHex("0000000000000000000000000000000000000000000000000000000000000000"))
-      .then(() => fail("promise must be rejected"))
-      .catch((error) => expect(error.message).toContain("not a valid secp256k1 private key"));
+      .then(() => {
+        fail("promise must be rejected");
+      })
+      .catch((error) => {
+        expect(error.message).toContain("not a valid secp256k1 private key");
+      });
     // value out of range (>= n)
     await Secp256k1.makeKeypair(fromHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"))
-      .then(() => fail("promise must be rejected"))
-      .catch((error) => expect(error.message).toContain("not a valid secp256k1 private key"));
+      .then(() => {
+        fail("promise must be rejected");
+      })
+      .catch((error) => {
+        expect(error.message).toContain("not a valid secp256k1 private key");
+      });
     await Secp256k1.makeKeypair(fromHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"))
-      .then(() => fail("promise must be rejected"))
-      .catch((error) => expect(error.message).toContain("not a valid secp256k1 private key"));
+      .then(() => {
+        fail("promise must be rejected");
+      })
+      .catch((error) => {
+        expect(error.message).toContain("not a valid secp256k1 private key");
+      });
   });
 
   it("creates signatures", async () => {
@@ -112,8 +132,12 @@ describe("Secp256k1", () => {
     const keypair = await Secp256k1.makeKeypair(privkey);
     const messageHash = new Uint8Array([]);
     await Secp256k1.createSignature(messageHash, keypair.privkey)
-      .then(() => fail("must not resolve"))
-      .catch((error) => expect(error).toMatch(/message hash must not be empty/i));
+      .then(() => {
+        fail("must not resolve");
+      })
+      .catch((error) => {
+        expect(error).toMatch(/message hash must not be empty/i);
+      });
   });
 
   it("throws for message hash longer than 32 bytes in signing", async () => {
@@ -121,8 +145,12 @@ describe("Secp256k1", () => {
     const keypair = await Secp256k1.makeKeypair(privkey);
     const messageHash = fromHex("11223344556677889900aabbccddeeff11223344556677889900aabbccddeeff11");
     await Secp256k1.createSignature(messageHash, keypair.privkey)
-      .then(() => fail("must not resolve"))
-      .catch((error) => expect(error).toMatch(/message hash length must not exceed 32 bytes/i));
+      .then(() => {
+        fail("must not resolve");
+      })
+      .catch((error) => {
+        expect(error).toMatch(/message hash length must not exceed 32 bytes/i);
+      });
   });
 
   it("verifies signatures", async () => {
@@ -173,8 +201,12 @@ describe("Secp256k1", () => {
     );
     const messageHash = new Uint8Array([]);
     await Secp256k1.verifySignature(dummySignature, messageHash, keypair.pubkey)
-      .then(() => fail("must not resolve"))
-      .catch((error) => expect(error).toMatch(/message hash must not be empty/i));
+      .then(() => {
+        fail("must not resolve");
+      })
+      .catch((error) => {
+        expect(error).toMatch(/message hash must not be empty/i);
+      });
   });
 
   it("throws for message hash longer than 32 bytes in verification", async () => {
@@ -188,8 +220,12 @@ describe("Secp256k1", () => {
     );
     const messageHash = fromHex("11223344556677889900aabbccddeeff11223344556677889900aabbccddeeff11");
     await Secp256k1.verifySignature(dummySignature, messageHash, keypair.privkey)
-      .then(() => fail("must not resolve"))
-      .catch((error) => expect(error).toMatch(/message hash length must not exceed 32 bytes/i));
+      .then(() => {
+        fail("must not resolve");
+      })
+      .catch((error) => {
+        expect(error).toMatch(/message hash length must not exceed 32 bytes/i);
+      });
   });
 
   it("verifies unnormalized pyca/cryptography signatures", async () => {

--- a/packages/crypto/src/secp256k1.ts
+++ b/packages/crypto/src/secp256k1.ts
@@ -116,7 +116,7 @@ export class Secp256k1 {
       case 33:
         return pubkey;
       case 65:
-        return secp256k1.Point.fromHex(pubkey).toRawBytes(true);
+        return secp256k1.Point.fromHex(pubkey).toBytes(true);
       default:
         throw new Error("Invalid pubkey length");
     }
@@ -130,7 +130,7 @@ export class Secp256k1 {
   public static uncompressPubkey(pubkey: Uint8Array): Uint8Array {
     switch (pubkey.length) {
       case 33:
-        return secp256k1.Point.fromHex(pubkey).toRawBytes(false);
+        return secp256k1.Point.fromHex(pubkey).toBytes(false);
       case 65:
         return pubkey;
       default:

--- a/packages/crypto/src/sha.ts
+++ b/packages/crypto/src/sha.ts
@@ -1,5 +1,4 @@
-import { sha256 as nobleSha256 } from "@noble/hashes/sha256";
-import { sha512 as nobleSha512 } from "@noble/hashes/sha512";
+import { sha256 as nobleSha256, sha512 as nobleSha512 } from "@noble/hashes/sha2.js";
 
 import { HashFunction } from "./hash";
 import { toRealUint8Array } from "./utils";

--- a/packages/crypto/src/sha.ts
+++ b/packages/crypto/src/sha.ts
@@ -15,7 +15,7 @@ export class Sha256 implements HashFunction {
     }
   }
 
-  public update(data: Uint8Array): Sha256 {
+  public update(data: Uint8Array): this {
     this.impl.update(toRealUint8Array(data));
     return this;
   }
@@ -41,7 +41,7 @@ export class Sha512 implements HashFunction {
     }
   }
 
-  public update(data: Uint8Array): Sha512 {
+  public update(data: Uint8Array): this {
     this.impl.update(toRealUint8Array(data));
     return this;
   }

--- a/packages/crypto/src/slip10.ts
+++ b/packages/crypto/src/slip10.ts
@@ -151,7 +151,7 @@ export class Slip10 {
   private static serializedPoint(curve: Slip10Curve, p: bigint): Uint8Array {
     switch (curve) {
       case Slip10Curve.Secp256k1:
-        return secp256k1.Point.BASE.multiply(p).toRawBytes(true);
+        return secp256k1.Point.BASE.multiply(p).toBytes(true);
       default:
         throw new Error("curve not supported");
     }

--- a/packages/encoding/src/ascii.ts
+++ b/packages/encoding/src/ascii.ts
@@ -7,7 +7,7 @@ export function toAscii(input: string): Uint8Array {
       // 0x7F delete character
       // 0x80–0xFF out of 7 bit ascii range
       if (charCode < 0x20 || charCode > 0x7e) {
-        throw new Error("Cannot encode character that is out of printable ASCII range: " + charCode);
+        throw new Error(`Cannot encode character that is out of printable ASCII range: ${charCode}`);
       }
       return charCode;
     });
@@ -22,7 +22,7 @@ export function fromAscii(data: Uint8Array): string {
       // 0x7F delete character
       // 0x80–0xFF out of 7 bit ascii range
       if (x < 0x20 || x > 0x7e) {
-        throw new Error("Cannot decode character that is out of printable ASCII range: " + x);
+        throw new Error(`Cannot decode character that is out of printable ASCII range: ${x}`);
       }
       return String.fromCharCode(x);
     });

--- a/packages/faucet-client/src/faucetclient.spec.ts
+++ b/packages/faucet-client/src/faucetclient.spec.ts
@@ -41,8 +41,12 @@ describe("FaucetClient", () => {
     pendingWithoutFaucet();
     const faucet = new FaucetClient(faucetUrl);
     await faucet.credit(defaultAddress, "ETH").then(
-      () => fail("must not resolve"),
-      (error) => expect(error).toMatch(/token is not available/i),
+      () => {
+        fail("must not resolve");
+      },
+      (error) => {
+        expect(error).toMatch(/token is not available/i);
+      },
     );
   });
 
@@ -52,8 +56,12 @@ describe("FaucetClient", () => {
 
     for (const address of ["be5cc2cc05db2cdb4313c18306a5157291cfdcd1", "1234L"]) {
       await faucet.credit(address, primaryToken).then(
-        () => fail("must not resolve"),
-        (error) => expect(error).toMatch(/address is not in the expected format for this chain/i),
+        () => {
+          fail("must not resolve");
+        },
+        (error) => {
+          expect(error).toMatch(/address is not in the expected format for this chain/i);
+        },
       );
     }
   });

--- a/packages/faucet/src/api/webserver.spec.ts
+++ b/packages/faucet/src/api/webserver.spec.ts
@@ -7,7 +7,8 @@ import { ChainConstants, Webserver } from "./webserver";
 
 function pendingWithoutSimapp(): void {
   if (!process.env.SIMAPP47_ENABLED && !process.env.SIMAPP50_ENABLED) {
-    return pending("Set SIMAPP{47,50}_ENABLED to enabled Stargate node-based tests");
+    pending("Set SIMAPP{47,50}_ENABLED to enabled Stargate node-based tests");
+    return;
   }
 }
 

--- a/packages/faucet/src/faucet.spec.ts
+++ b/packages/faucet/src/faucet.spec.ts
@@ -8,7 +8,8 @@ import { TokenConfiguration } from "./tokenmanager";
 
 function pendingWithoutSimapp(): void {
   if (!process.env.SIMAPP47_ENABLED && !process.env.SIMAPP50_ENABLED) {
-    return pending("Set SIMAPP{47,50}_ENABLED to enabled Stargate node-based tests");
+    pending("Set SIMAPP{47,50}_ENABLED to enabled Stargate node-based tests");
+    return;
   }
 }
 

--- a/packages/json-rpc/src/jsonrpcclient.spec.ts
+++ b/packages/json-rpc/src/jsonrpcclient.spec.ts
@@ -28,7 +28,9 @@ function makeSimpleMessagingConnection(
 
   return {
     responseStream: Stream.create(producer),
-    sendRequest: (request) => worker.postMessage(request),
+    sendRequest: (request) => {
+      worker.postMessage(request);
+    },
   };
 }
 

--- a/packages/json-rpc/src/workers/dummyservice.worker.ts
+++ b/packages/json-rpc/src/workers/dummyservice.worker.ts
@@ -65,5 +65,7 @@ onmessage = (event) => {
   }
 
   const response = handleRequest(event);
-  setTimeout(() => postMessage(response), 50);
+  setTimeout(() => {
+    postMessage(response);
+  }, 50);
 };

--- a/packages/ledger-amino/src/testutils.spec.ts
+++ b/packages/ledger-amino/src/testutils.spec.ts
@@ -14,7 +14,8 @@ export function ledgerEnabled(): boolean {
 
 export function pendingWithoutLedger(): void {
   if (!ledgerEnabled()) {
-    return pending("Set LEDGER_ENABLED to enable Ledger-based tests");
+    pending("Set LEDGER_ENABLED to enable Ledger-based tests");
+    return;
   }
 }
 
@@ -24,7 +25,8 @@ export function simappEnabled(): boolean {
 
 export function pendingWithoutSimapp(): void {
   if (!simappEnabled()) {
-    return pending("Set SIMAPP{47,50}_ENABLED to enable Simapp-based tests");
+    pending("Set SIMAPP{47,50}_ENABLED to enable Simapp-based tests");
+    return;
   }
 }
 

--- a/packages/math/src/integers.ts
+++ b/packages/math/src/integers.ts
@@ -41,7 +41,7 @@ export class Uint32 implements Integer, WithByteConverters {
 
     for (let i = 0; i < bytes.length; ++i) {
       if (!Number.isInteger(bytes[i]) || bytes[i] > 255 || bytes[i] < 0) {
-        throw new Error("Invalid value in byte. Found: " + bytes[i]);
+        throw new Error(`Invalid value in byte. Found: ${bytes[i]}`);
       }
     }
 
@@ -204,7 +204,7 @@ export class Uint64 implements Integer, WithByteConverters {
     for (const byte of beBytes) {
       value *= 256n;
       if (!Number.isInteger(byte) || byte > 255 || byte < 0) {
-        throw new Error("Invalid value in byte. Found: " + byte);
+        throw new Error(`Invalid value in byte. Found: ${byte}`);
       }
       value += BigInt(byte);
     }

--- a/packages/socket/src/queueingstreamingsocket.spec.ts
+++ b/packages/socket/src/queueingstreamingsocket.spec.ts
@@ -32,7 +32,9 @@ describe("QueueingStreamingSocket", () => {
       });
 
       socket.connect();
-      requests.forEach((request) => socket.queueRequest(request));
+      requests.forEach((request) => {
+        socket.queueRequest(request);
+      });
     });
 
     it("can queue requests without a connection and process them later", (done) => {
@@ -51,7 +53,9 @@ describe("QueueingStreamingSocket", () => {
         },
       });
 
-      requests.forEach((request) => socket.queueRequest(request));
+      requests.forEach((request) => {
+        socket.queueRequest(request);
+      });
       setTimeout(() => {
         expect(socket.getQueueLength()).toEqual(3);
         socket.connect();
@@ -71,7 +75,9 @@ describe("QueueingStreamingSocket", () => {
             done();
           }
         },
-        complete: () => done.fail("Stream completed"),
+        complete: () => {
+          done.fail("Stream completed");
+        },
       });
 
       socket.connect();
@@ -89,7 +95,9 @@ describe("QueueingStreamingSocket", () => {
       socket.connect();
       socket.disconnect();
 
-      requests.forEach((request) => socket.queueRequest(request));
+      requests.forEach((request) => {
+        socket.queueRequest(request);
+      });
 
       socket.events.subscribe({
         next: (event) => {
@@ -148,7 +156,9 @@ describe("QueueingStreamingSocket", () => {
       setTimeout(() => {
         socket.disconnect();
         socket.reconnect();
-        setTimeout(() => socket.disconnect(), 1000);
+        setTimeout(() => {
+          socket.disconnect();
+        }, 1000);
       }, 1000);
     });
   });

--- a/packages/socket/src/queueingstreamingsocket.ts
+++ b/packages/socket/src/queueingstreamingsocket.ts
@@ -46,7 +46,9 @@ export class QueueingStreamingSocket {
         if (!this.eventProducerListener) throw new Error("No event producer listener set");
         this.eventProducerListener.next(event);
       },
-      error: () => this.connectionStatusProducer.update(ConnectionStatus.Disconnected),
+      error: () => {
+        this.connectionStatusProducer.update(ConnectionStatus.Disconnected);
+      },
     });
   }
 
@@ -57,7 +59,9 @@ export class QueueingStreamingSocket {
         this.connectionStatusProducer.update(ConnectionStatus.Connected);
         return this.processQueue();
       },
-      () => this.connectionStatusProducer.update(ConnectionStatus.Disconnected),
+      () => {
+        this.connectionStatusProducer.update(ConnectionStatus.Disconnected);
+      },
     );
     this.socket.connect();
   }
@@ -74,7 +78,9 @@ export class QueueingStreamingSocket {
         if (!this.eventProducerListener) throw new Error("No event producer listener set");
         this.eventProducerListener.next(event);
       },
-      error: () => this.connectionStatusProducer.update(ConnectionStatus.Disconnected),
+      error: () => {
+        this.connectionStatusProducer.update(ConnectionStatus.Disconnected);
+      },
     });
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.socket.connected.then(() => {

--- a/packages/socket/src/reconnectingsocket.ts
+++ b/packages/socket/src/reconnectingsocket.ts
@@ -55,10 +55,9 @@ export class ReconnectingSocket {
             clearTimeout(this.reconnectTimeout);
             this.reconnectTimeout = null;
           }
-          this.reconnectTimeout = setTimeout(
-            () => this.socket.reconnect(),
-            ReconnectingSocket.calculateTimeout(this.timeoutIndex++),
-          );
+          this.reconnectTimeout = setTimeout(() => {
+            this.socket.reconnect();
+          }, ReconnectingSocket.calculateTimeout(this.timeoutIndex++));
         }
       },
     });

--- a/packages/socket/src/socketwrapper.spec.ts
+++ b/packages/socket/src/socketwrapper.spec.ts
@@ -21,8 +21,12 @@ describe("SocketWrapper", () => {
 
     const socket = new SocketWrapper(
       socketServerUrl,
-      () => done.fail("Got unexpected message event"),
-      (error) => done.fail(error.message || "Unknown socket error"),
+      () => {
+        done.fail("Got unexpected message event");
+      },
+      (error) => {
+        done.fail(error.message || "Unknown socket error");
+      },
       () => {
         socket.disconnect();
         done();
@@ -37,7 +41,9 @@ describe("SocketWrapper", () => {
 
     const socket = new SocketWrapper(
       socketServerUrlNonExisting,
-      () => done.fail("Got unexpected message event"),
+      () => {
+        done.fail("Got unexpected message event");
+      },
       (error) => {
         if (error.message) {
           // error message only available in nodejs
@@ -45,7 +51,9 @@ describe("SocketWrapper", () => {
         }
         done();
       },
-      () => done.fail("Got unexpected open event"),
+      () => {
+        done.fail("Got unexpected open event");
+      },
     );
     expect(socket).toBeTruthy();
     socket.connect();
@@ -57,14 +65,18 @@ describe("SocketWrapper", () => {
 
     const socket = new SocketWrapper(
       socketServerUrlNonExisting,
-      () => done.fail("Got unexpected message event"),
+      () => {
+        done.fail("Got unexpected message event");
+      },
       (error) => {
         expect(error).toBeTruthy();
 
         // All done. Delay test end to ensure the timeout is not triggered
         setTimeout(done, timeout * 1.3);
       },
-      () => done.fail("Got unexpected open event"),
+      () => {
+        done.fail("Got unexpected open event");
+      },
       () => 0,
       timeout,
     );
@@ -77,8 +89,12 @@ describe("SocketWrapper", () => {
 
     const socket = new SocketWrapper(
       socketServerUrlSlow,
-      () => done.fail("Got unexpected message event"),
-      (error) => done.fail(error.message || "Unknown socket error"),
+      () => {
+        done.fail("Got unexpected message event");
+      },
+      (error) => {
+        done.fail(error.message || "Unknown socket error");
+      },
       () => {
         socket.disconnect();
         done();
@@ -93,17 +109,29 @@ describe("SocketWrapper", () => {
 
     const socket = new SocketWrapper(
       socketServerUrlSlow,
-      () => fail("Got unexpected message event"),
-      (error) => fail(error.message || "Unknown socket error"),
-      () => fail("Got unexpected opened event"),
-      () => fail("Got unexpected closed event"),
+      () => {
+        fail("Got unexpected message event");
+      },
+      (error) => {
+        fail(error.message || "Unknown socket error");
+      },
+      () => {
+        fail("Got unexpected opened event");
+      },
+      () => {
+        fail("Got unexpected closed event");
+      },
       2_000,
     );
     socket.connect();
 
     await socket.connected
-      .then(() => fail("must not resolve"))
-      .catch((error) => expect(error).toMatch(/connection attempt timed out/i));
+      .then(() => {
+        fail("must not resolve");
+      })
+      .catch((error) => {
+        expect(error).toMatch(/connection attempt timed out/i);
+      });
   });
 
   it("can connect and disconnect", (done) => {
@@ -113,8 +141,12 @@ describe("SocketWrapper", () => {
 
     const socket = new SocketWrapper(
       socketServerUrl,
-      () => done.fail("Got unexpected message event"),
-      (error) => done.fail(error.message || "Unknown socket error"),
+      () => {
+        done.fail("Got unexpected message event");
+      },
+      (error) => {
+        done.fail(error.message || "Unknown socket error");
+      },
       () => {
         opened += 1;
         socket.disconnect();
@@ -135,9 +167,15 @@ describe("SocketWrapper", () => {
 
     const socket = new SocketWrapper(
       socketServerUrl,
-      () => done.fail("Got unexpected message event"),
-      (error) => done.fail(error.message || "Unknown socket error"),
-      () => done.fail("Got unexpected open event"),
+      () => {
+        done.fail("Got unexpected message event");
+      },
+      (error) => {
+        done.fail(error.message || "Unknown socket error");
+      },
+      () => {
+        done.fail("Got unexpected open event");
+      },
       (closeEvent) => {
         expect(closeEvent.wasClean).toEqual(false);
         expect(closeEvent.code).toEqual(4001);
@@ -154,9 +192,15 @@ describe("SocketWrapper", () => {
 
     const socket = new SocketWrapper(
       socketServerUrl,
-      () => done.fail("Got unexpected message event"),
-      (error) => done.fail(error.message || "Unknown socket error"),
-      () => done.fail("Got unexpected open event"),
+      () => {
+        done.fail("Got unexpected message event");
+      },
+      (error) => {
+        done.fail(error.message || "Unknown socket error");
+      },
+      () => {
+        done.fail("Got unexpected open event");
+      },
       (closeEvent) => {
         expect(closeEvent.wasClean).toEqual(false);
         expect(closeEvent.code).toEqual(4001);
@@ -185,7 +229,9 @@ describe("SocketWrapper", () => {
           socket.disconnect();
         }
       },
-      (error) => done.fail(error.message || "Unknown socket error"),
+      (error) => {
+        done.fail(error.message || "Unknown socket error");
+      },
       async () => {
         await socket.send("aabbccdd");
         await socket.send("whatever");
@@ -213,9 +259,13 @@ describe("SocketWrapper", () => {
         expect(response.data).toEqual("Hello world");
         socket.disconnect();
       },
-      (error) => done.fail(error.message || "Unknown socket error"),
+      (error) => {
+        done.fail(error.message || "Unknown socket error");
+      },
       undefined,
-      () => done(),
+      () => {
+        done();
+      },
       timeoutPeriodLength,
     );
     socket.connect();
@@ -228,15 +278,21 @@ describe("SocketWrapper", () => {
 
     const socket = new SocketWrapper(
       socketServerUrl,
-      () => done.fail("Got unexpected message event"),
-      (error) => done.fail(error.message || "Unknown socket error"),
+      () => {
+        done.fail("Got unexpected message event");
+      },
+      (error) => {
+        done.fail(error.message || "Unknown socket error");
+      },
       () => {
         socket.disconnect();
       },
       () => {
         socket
           .send("la li lu")
-          .then(() => done.fail("must not resolve"))
+          .then(() => {
+            done.fail("must not resolve");
+          })
           .catch((error) => {
             expect(error).toMatch(/socket was closed/i);
             done();

--- a/packages/socket/src/socketwrapper.ts
+++ b/packages/socket/src/socketwrapper.ts
@@ -175,7 +175,10 @@ export class SocketWrapper {
       }
 
       if (environmentIsNodeJs()) {
-        this.socket.send(data, (err) => (err ? reject(err) : resolve()));
+        this.socket.send(data, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
       } else {
         // Browser websocket send method does not accept a callback
         this.socket.send(data);

--- a/packages/socket/src/streamingsocket.spec.ts
+++ b/packages/socket/src/streamingsocket.spec.ts
@@ -48,8 +48,12 @@ describe("StreamingSocket", () => {
     socket.connect();
 
     await socket.connected
-      .then(() => fail("must not resolve"))
-      .catch((error) => expect(error).toMatch(/connection attempt timed out/i));
+      .then(() => {
+        fail("must not resolve");
+      })
+      .catch((error) => {
+        expect(error).toMatch(/connection attempt timed out/i);
+      });
   });
 
   it("can send events when connected", async () => {

--- a/packages/stargate/src/testutils.spec.ts
+++ b/packages/stargate/src/testutils.spec.ts
@@ -30,7 +30,8 @@ export function simappEnabled(): boolean {
 
 export function pendingWithoutSimapp(): void {
   if (!simappEnabled()) {
-    return pending("Set SIMAPP{47,50}_ENABLED to enable Simapp based tests");
+    pending("Set SIMAPP{47,50}_ENABLED to enable Simapp based tests");
+    return;
   }
 }
 
@@ -40,7 +41,8 @@ export function slowSimappEnabled(): boolean {
 
 export function pendingWithoutSlowSimapp(): void {
   if (!slowSimappEnabled()) {
-    return pending("Set SLOW_SIMAPP{47,50}_ENABLED to enable slow Simapp based tests");
+    pending("Set SLOW_SIMAPP{47,50}_ENABLED to enable slow Simapp based tests");
+    return;
   }
 }
 

--- a/packages/stream/src/concat.spec.ts
+++ b/packages/stream/src/concat.spec.ts
@@ -12,7 +12,9 @@ describe("concat", () => {
     const expected: string[] = [];
 
     concatenatedStream.addListener({
-      next: (value) => expect(value).toEqual(expected.shift()!),
+      next: (value) => {
+        expect(value).toEqual(expected.shift()!);
+      },
       complete: () => {
         expect(expected.length).toEqual(0);
         done();
@@ -27,7 +29,9 @@ describe("concat", () => {
     const expected = ["1", "2", "3"];
 
     concatenatedStream.addListener({
-      next: (value) => expect(value).toEqual(expected.shift()!),
+      next: (value) => {
+        expect(value).toEqual(expected.shift()!);
+      },
       complete: () => {
         expect(expected.length).toEqual(0);
         done();
@@ -43,7 +47,9 @@ describe("concat", () => {
     const expected = ["1", "2", "3", "a", "b", "c"];
 
     concatenatedStream.addListener({
-      next: (value) => expect(value).toEqual(expected.shift()!),
+      next: (value) => {
+        expect(value).toEqual(expected.shift()!);
+      },
       complete: () => {
         expect(expected.length).toEqual(0);
         done();
@@ -60,7 +66,9 @@ describe("concat", () => {
     const expected = ["1", "2", "3", "a", "b", "c", "X", "Y", "Z"];
 
     concatenatedStream.addListener({
-      next: (value) => expect(value).toEqual(expected.shift()!),
+      next: (value) => {
+        expect(value).toEqual(expected.shift()!);
+      },
       complete: () => {
         expect(expected.length).toEqual(0);
         done();
@@ -76,7 +84,9 @@ describe("concat", () => {
     const expected = ["a", "b", "c", "1", "2", "3"];
 
     concatenatedStream.addListener({
-      next: (value) => expect(value).toEqual(expected.shift()!),
+      next: (value) => {
+        expect(value).toEqual(expected.shift()!);
+      },
       complete: () => {
         expect(expected.length).toEqual(0);
         done();
@@ -92,7 +102,9 @@ describe("concat", () => {
     const expected = [0, 1, 2, 0, 1];
 
     concatenatedStream.addListener({
-      next: (value) => expect(value).toEqual(expected.shift()!),
+      next: (value) => {
+        expect(value).toEqual(expected.shift()!);
+      },
       complete: () => {
         expect(expected.length).toEqual(0);
         done();
@@ -108,7 +120,9 @@ describe("concat", () => {
     const expected = [0, 1, 2, 30, 40, 50, 60];
 
     concatenatedStream.addListener({
-      next: (value) => expect(value).toEqual(expected.shift()!),
+      next: (value) => {
+        expect(value).toEqual(expected.shift()!);
+      },
       complete: () => {
         expect(expected.length).toEqual(0);
         done();
@@ -125,7 +139,9 @@ describe("concat", () => {
     const expected = [0, 1, 2, 0, 1, 2];
 
     concatenatedStream.addListener({
-      next: (value) => expect(value).toEqual(expected.shift()!),
+      next: (value) => {
+        expect(value).toEqual(expected.shift()!);
+      },
       complete: () => {
         expect(expected.length).toEqual(0);
         done();
@@ -144,7 +160,9 @@ describe("concat", () => {
     let producerValue = 0;
     const loggingProducer: Producer<string> = {
       start: (listener) => {
-        producerInterval = setInterval(() => listener.next(`event${producerValue++}`), intervalDuration);
+        producerInterval = setInterval(() => {
+          listener.next(`event${producerValue++}`);
+        }, intervalDuration);
         producerActiveLog.push(true);
       },
       stop: () => {
@@ -160,8 +178,12 @@ describe("concat", () => {
     expect(producerActiveLog).toEqual([]);
 
     const subscription = concatenatedStream.subscribe({
-      next: (value) => expect(value).toEqual(expected.shift()!),
-      complete: () => done.fail(),
+      next: (value) => {
+        expect(value).toEqual(expected.shift()!);
+      },
+      complete: () => {
+        done.fail();
+      },
       error: done.fail,
     });
 
@@ -180,8 +202,12 @@ describe("concat", () => {
       expect(producerActiveLog).toEqual([true, false]);
 
       const subscription2 = concatenatedStream.subscribe({
-        next: (value) => expect(value).toEqual(expected.shift()!),
-        complete: () => done.fail(),
+        next: (value) => {
+          expect(value).toEqual(expected.shift()!);
+        },
+        complete: () => {
+          done.fail();
+        },
         error: done.fail,
       });
 

--- a/packages/stream/src/defaultvalueproducer.spec.ts
+++ b/packages/stream/src/defaultvalueproducer.spec.ts
@@ -57,7 +57,9 @@ describe("DefaultValueProducer", () => {
         expect(error).toEqual("oh no :(");
         done();
       },
-      complete: () => done.fail("Stream must not complete successfully"),
+      complete: () => {
+        done.fail("Stream must not complete successfully");
+      },
     });
 
     producer.update(1);

--- a/packages/stream/src/promise.spec.ts
+++ b/packages/stream/src/promise.spec.ts
@@ -33,7 +33,9 @@ describe("promise", () => {
     it("works for delayed resolution", async () => {
       const inputPromise = new Promise<number[]>((resolve) => {
         // resolve after 50 ms
-        setTimeout(() => resolve([1, 2, 3]), 50);
+        setTimeout(() => {
+          resolve([1, 2, 3]);
+        }, 50);
       });
       const stream = fromListPromise(inputPromise);
 
@@ -77,8 +79,12 @@ describe("promise", () => {
 
     it("rejects for simple stream with less events than count", async () => {
       await toListPromise(Stream.fromArray([1, 6, 92]), 5)
-        .then(() => fail("must not resolve"))
-        .catch((error) => expect(error).toMatch(/stream completed before all events could be collected/i));
+        .then(() => {
+          fail("must not resolve");
+        })
+        .catch((error) => {
+          expect(error).toMatch(/stream completed before all events could be collected/i);
+        });
     });
 
     it("works for async stream", async () => {
@@ -113,8 +119,12 @@ describe("promise", () => {
 
     it("rejects for stream with no events", async () => {
       await firstEvent(Stream.fromArray([]))
-        .then(() => fail("must not resolve"))
-        .catch((error) => expect(error).toMatch(/stream completed before all events could be collected/i));
+        .then(() => {
+          fail("must not resolve");
+        })
+        .catch((error) => {
+          expect(error).toMatch(/stream completed before all events could be collected/i);
+        });
     });
 
     it("works for async stream", async () => {

--- a/packages/stream/src/promise.ts
+++ b/packages/stream/src/promise.ts
@@ -14,7 +14,9 @@ export function fromListPromise<T>(promise: Promise<Iterable<T>>): Stream<T> {
           }
           listener.complete();
         })
-        .catch((error) => listener.error(error));
+        .catch((error) => {
+          listener.error(error);
+        });
     },
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     stop: () => {},
@@ -52,7 +54,9 @@ export async function toListPromise<T>(stream: Stream<T>, count: number): Promis
             `Collected ${events.length}, expected ${count}`,
         );
       },
-      error: (error) => reject(error),
+      error: (error) => {
+        reject(error);
+      },
     });
   });
 }

--- a/packages/stream/src/reducer.ts
+++ b/packages/stream/src/reducer.ts
@@ -46,7 +46,7 @@ export class Reducer<T, U> {
   }
 }
 
-function increment<T>(sum: number, _: T): number {
+function increment(sum: number, _: unknown): number {
   return sum + 1;
 }
 

--- a/packages/stream/src/valueandupdates.spec.ts
+++ b/packages/stream/src/valueandupdates.spec.ts
@@ -81,8 +81,12 @@ describe("ValueAndUpdates", () => {
         expect(value).toEqual(123);
         done();
       },
-      complete: () => done.fail(".updates stream must not complete"),
-      error: (e) => done.fail(e),
+      complete: () => {
+        done.fail(".updates stream must not complete");
+      },
+      error: (e) => {
+        done.fail(e);
+      },
     };
 
     const listener1: Listener<number> = {
@@ -90,8 +94,12 @@ describe("ValueAndUpdates", () => {
         expect(value).toEqual(123);
         vau.updates.addListener(listener2);
       },
-      complete: () => done.fail(".updates stream must not complete"),
-      error: (e) => done.fail(e),
+      complete: () => {
+        done.fail(".updates stream must not complete");
+      },
+      error: (e) => {
+        done.fail(e);
+      },
     };
 
     vau.updates.addListener(listener1);
@@ -107,8 +115,12 @@ describe("ValueAndUpdates", () => {
         expect(value).toEqual(99);
         done();
       },
-      complete: () => done.fail(".updates stream must not complete"),
-      error: (e) => done.fail(e),
+      complete: () => {
+        done.fail(".updates stream must not complete");
+      },
+      error: (e) => {
+        done.fail(e);
+      },
     };
 
     const listener1: Listener<number> = {
@@ -116,8 +128,12 @@ describe("ValueAndUpdates", () => {
         expect(value).toEqual(99);
         vau.updates.addListener(listener2);
       },
-      complete: () => done.fail(".updates stream must not complete"),
-      error: (e) => done.fail(e),
+      complete: () => {
+        done.fail(".updates stream must not complete");
+      },
+      error: (e) => {
+        done.fail(e);
+      },
     };
 
     vau.updates.addListener(listener1);
@@ -140,22 +156,38 @@ describe("ValueAndUpdates", () => {
           done();
         }
       },
-      complete: () => done.fail(".updates stream must not complete"),
-      error: (e) => done.fail(e),
+      complete: () => {
+        done.fail(".updates stream must not complete");
+      },
+      error: (e) => {
+        done.fail(e);
+      },
     });
 
-    setTimeout(() => producer.update(22), 10);
-    setTimeout(() => producer.update(33), 20);
-    setTimeout(() => producer.update(44), 30);
+    setTimeout(() => {
+      producer.update(22);
+    }, 10);
+    setTimeout(() => {
+      producer.update(33);
+    }, 20);
+    setTimeout(() => {
+      producer.update(44);
+    }, 30);
   });
 
   it("can wait for value", async () => {
     const producer = new DefaultValueProducer(11);
     const vau = new ValueAndUpdates(producer);
 
-    setTimeout(() => producer.update(22), 10);
-    setTimeout(() => producer.update(33), 20);
-    setTimeout(() => producer.update(44), 30);
+    setTimeout(() => {
+      producer.update(22);
+    }, 10);
+    setTimeout(() => {
+      producer.update(33);
+    }, 20);
+    setTimeout(() => {
+      producer.update(44);
+    }, 30);
 
     await vau.waitFor(33);
     expect(vau.value).toEqual(33);
@@ -168,9 +200,15 @@ describe("ValueAndUpdates", () => {
     const producer = new DefaultValueProducer(11);
     const vau = new ValueAndUpdates(producer);
 
-    setTimeout(() => producer.update(22), 10);
-    setTimeout(() => producer.update(33), 20);
-    setTimeout(() => producer.update(44), 30);
+    setTimeout(() => {
+      producer.update(22);
+    }, 10);
+    setTimeout(() => {
+      producer.update(33);
+    }, 20);
+    setTimeout(() => {
+      producer.update(44);
+    }, 30);
 
     await vau.waitFor((v) => v > 30);
     expect(vau.value).toEqual(33);
@@ -183,8 +221,12 @@ describe("ValueAndUpdates", () => {
     const producer = new DefaultValueProducer(11);
     const vau = new ValueAndUpdates(producer);
 
-    setTimeout(() => producer.update(22), 10);
-    setTimeout(() => producer.update(33), 20);
+    setTimeout(() => {
+      producer.update(22);
+    }, 10);
+    setTimeout(() => {
+      producer.update(33);
+    }, 20);
 
     {
       const result = await vau.waitFor(22);
@@ -201,10 +243,16 @@ describe("ValueAndUpdates", () => {
     it("propagates error from stream", async () => {
       const producer = new DefaultValueProducer(1);
       const vau = new ValueAndUpdates(producer);
-      setTimeout(() => producer.error(new Error("something went wrong")), 10);
+      setTimeout(() => {
+        producer.error(new Error("something went wrong"));
+      }, 10);
       await vau.waitFor(3).then(
-        () => fail("must not resolve"),
-        (error) => expect(error).toMatch(/something went wrong/),
+        () => {
+          fail("must not resolve");
+        },
+        (error) => {
+          expect(error).toMatch(/something went wrong/);
+        },
       );
     });
   });

--- a/packages/stream/src/valueandupdates.ts
+++ b/packages/stream/src/valueandupdates.ts
@@ -41,7 +41,9 @@ export class ValueAndUpdates<T> {
 
             // MemoryStream.subscribe() calls next with the last value.
             // Make async to ensure the subscription exists
-            setTimeout(() => subscription.unsubscribe(), 0);
+            setTimeout(() => {
+              subscription.unsubscribe();
+            }, 0);
           }
         },
         complete: () => {

--- a/packages/tendermint-rpc/src/comet38/comet38client.spec.ts
+++ b/packages/tendermint-rpc/src/comet38/comet38client.spec.ts
@@ -682,7 +682,9 @@ function websocketTestSuite(rpcFactory: () => RpcClient, expected: ExpectedValue
           }
         },
         error: done.fail,
-        complete: () => done.fail("Stream completed before we are done"),
+        complete: () => {
+          done.fail("Stream completed before we are done");
+        },
       });
     })().catch(done.fail);
   });

--- a/packages/tendermint-rpc/src/rpcclients/http.ts
+++ b/packages/tendermint-rpc/src/rpcclients/http.ts
@@ -10,12 +10,11 @@ function filterBadStatus(res: any): any {
  *
  * For some reason, fetch does not complain about missing server-side CORS support.
  */
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function http(
   method: "POST",
   url: string,
   headers: Record<string, string> | undefined,
-  request?: any,
+  request?: Record<string, any>,
   timeout?: number,
 ): Promise<any> {
   const settings: RequestInit = {

--- a/packages/tendermint-rpc/src/rpcclients/httpbatchclient.spec.ts
+++ b/packages/tendermint-rpc/src/rpcclients/httpbatchclient.spec.ts
@@ -25,8 +25,12 @@ describe("HttpBatchClient", () => {
 
     await client
       .execute(createJsonRpcRequest("no-such-method"))
-      .then(() => fail("must not resolve"))
-      .catch((error) => expect(error).toBeTruthy());
+      .then(() => {
+        fail("must not resolve");
+      })
+      .catch((error) => {
+        expect(error).toBeTruthy();
+      });
 
     client.disconnect();
   });

--- a/packages/tendermint-rpc/src/rpcclients/httpbatchclient.ts
+++ b/packages/tendermint-rpc/src/rpcclients/httpbatchclient.ts
@@ -53,7 +53,9 @@ export class HttpBatchClient implements RpcClient {
       this.url = endpoint.url;
       this.headers = endpoint.headers;
     }
-    this.timer = setInterval(() => this.tick(), options.dispatchInterval);
+    this.timer = setInterval(() => {
+      this.tick();
+    }, options.dispatchInterval);
     this.validate();
   }
 

--- a/packages/tendermint-rpc/src/rpcclients/httpclient.spec.ts
+++ b/packages/tendermint-rpc/src/rpcclients/httpclient.spec.ts
@@ -24,8 +24,12 @@ describe("HttpClient", () => {
 
     await client
       .execute(createJsonRpcRequest("no-such-method"))
-      .then(() => fail("must not resolve"))
-      .catch((error) => expect(error).toBeTruthy());
+      .then(() => {
+        fail("must not resolve");
+      })
+      .catch((error) => {
+        expect(error).toBeTruthy();
+      });
 
     client.disconnect();
   });

--- a/packages/tendermint-rpc/src/rpcclients/websocketclient.spec.ts
+++ b/packages/tendermint-rpc/src/rpcclients/websocketclient.spec.ts
@@ -31,8 +31,12 @@ describe("WebsocketClient", () => {
 
     await client
       .execute(createJsonRpcRequest("no-such-method"))
-      .then(() => fail("must not resolve"))
-      .catch((error) => expect(error).toBeTruthy());
+      .then(() => {
+        fail("must not resolve");
+      })
+      .catch((error) => {
+        expect(error).toBeTruthy();
+      });
 
     client.disconnect();
   });
@@ -50,7 +54,9 @@ describe("WebsocketClient", () => {
 
     const subscription = headers.subscribe({
       error: done.fail,
-      complete: () => done.fail("subscription should not complete"),
+      complete: () => {
+        done.fail("subscription should not complete");
+      },
       next: (event: SubscriptionEvent) => {
         events.push(event);
         expect(event.query).toEqual(query);
@@ -113,7 +119,9 @@ describe("WebsocketClient", () => {
 
     const subscription = headers.subscribe({
       error: done.fail,
-      complete: () => done.fail("subscription should not complete"),
+      complete: () => {
+        done.fail("subscription should not complete");
+      },
       next: (event: SubscriptionEvent) => {
         events.push(event);
         expect(event.query).toEqual(query);
@@ -134,7 +142,9 @@ describe("WebsocketClient", () => {
 
     client
       .execute(createJsonRpcRequest("status"))
-      .then((startusResponse) => expect(startusResponse).toBeTruthy())
+      .then((startusResponse) => {
+        expect(startusResponse).toBeTruthy();
+      })
       .catch(done.fail);
   });
 
@@ -149,7 +159,9 @@ describe("WebsocketClient", () => {
 
     const receivedEvents: SubscriptionEvent[] = [];
 
-    setTimeout(() => client.disconnect(), blockTime);
+    setTimeout(() => {
+      client.disconnect();
+    }, blockTime);
 
     headers.subscribe({
       error: done.fail,
@@ -172,8 +184,12 @@ describe("WebsocketClient", () => {
 
     await client
       .execute(createJsonRpcRequest("health"))
-      .then(() => fail("must not resolve"))
-      .catch((error) => expect(error).toMatch(/socket has disconnected/i));
+      .then(() => {
+        fail("must not resolve");
+      })
+      .catch((error) => {
+        expect(error).toMatch(/socket has disconnected/i);
+      });
   });
 
   it("fails when listening to a disconnected client", (done) => {

--- a/packages/tendermint-rpc/src/tendermint34/tendermint34client.spec.ts
+++ b/packages/tendermint-rpc/src/tendermint34/tendermint34client.spec.ts
@@ -673,7 +673,9 @@ function websocketTestSuite(rpcFactory: () => RpcClient, expected: ExpectedValue
           }
         },
         error: done.fail,
-        complete: () => done.fail("Stream completed before we are done"),
+        complete: () => {
+          done.fail("Stream completed before we are done");
+        },
       });
     })().catch(done.fail);
   });

--- a/packages/tendermint-rpc/src/tendermint37/tendermint37client.spec.ts
+++ b/packages/tendermint-rpc/src/tendermint37/tendermint37client.spec.ts
@@ -679,7 +679,9 @@ function websocketTestSuite(rpcFactory: () => RpcClient, expected: ExpectedValue
           }
         },
         error: done.fail,
-        complete: () => done.fail("Stream completed before we are done"),
+        complete: () => {
+          done.fail("Stream completed before we are done");
+        },
       });
     })().catch(done.fail);
   });

--- a/packages/utils/src/assert.spec.ts
+++ b/packages/utils/src/assert.spec.ts
@@ -3,16 +3,22 @@ import { assert, assertDefined, assertDefinedAndNotNull } from "./assert";
 describe("assert", () => {
   describe("assert", () => {
     it("assert should not throw an error when condition is truthy", () => {
-      expect(() => assert(true)).not.toThrow();
+      expect(() => {
+        assert(true);
+      }).not.toThrow();
     });
 
     it("assert should throw an error with default message when condition is falsy", () => {
-      expect(() => assert(false)).toThrowError("condition is not truthy");
+      expect(() => {
+        assert(false);
+      }).toThrowError("condition is not truthy");
     });
 
     it("assert should throw an error with custom message when condition is falsy", () => {
       const errorMessage = "Custom error message";
-      expect(() => assert(false, errorMessage)).toThrowError(errorMessage);
+      expect(() => {
+        assert(false, errorMessage);
+      }).toThrowError(errorMessage);
     });
   });
 
@@ -51,17 +57,23 @@ describe("assert", () => {
     it("throws for undefined values", () => {
       {
         const value: number | undefined = undefined;
-        expect(() => assertDefined(value)).toThrowError("value is undefined");
+        expect(() => {
+          assertDefined(value);
+        }).toThrowError("value is undefined");
       }
       {
         let value: string | undefined;
-        expect(() => assertDefined(value)).toThrowError("value is undefined");
+        expect(() => {
+          assertDefined(value);
+        }).toThrowError("value is undefined");
       }
     });
 
     it("throws with custom message", () => {
       const value: number | undefined = undefined;
-      expect(() => assertDefined(value, "Bug in the data source")).toThrowError("Bug in the data source");
+      expect(() => {
+        assertDefined(value, "Bug in the data source");
+      }).toThrowError("Bug in the data source");
     });
   });
 
@@ -95,24 +107,30 @@ describe("assert", () => {
     it("throws for undefined values", () => {
       {
         const value: number | undefined | null = undefined;
-        expect(() => assertDefinedAndNotNull(value)).toThrowError("value is undefined or null");
+        expect(() => {
+          assertDefinedAndNotNull(value);
+        }).toThrowError("value is undefined or null");
       }
       {
         let value: string | undefined | null;
-        expect(() => assertDefinedAndNotNull(value)).toThrowError("value is undefined or null");
+        expect(() => {
+          assertDefinedAndNotNull(value);
+        }).toThrowError("value is undefined or null");
       }
     });
 
     it("throws for null values", () => {
       const value: number | undefined | null = null;
-      expect(() => assertDefinedAndNotNull(value)).toThrowError("value is undefined or null");
+      expect(() => {
+        assertDefinedAndNotNull(value);
+      }).toThrowError("value is undefined or null");
     });
 
     it("throws with custom message", () => {
       const value: number | undefined = undefined;
-      expect(() => assertDefinedAndNotNull(value, "Bug in the data source")).toThrowError(
-        "Bug in the data source",
-      );
+      expect(() => {
+        assertDefinedAndNotNull(value, "Bug in the data source");
+      }).toThrowError("Bug in the data source");
     });
   });
 });


### PR DESCRIPTION
[`no-non-null-assertion`](https://typescript-eslint.io/rules/no-non-null-assertion/) is disabled in many places, but it wasn't actually enabled anywhere. Now it is, as part of `strict-type-checked`.


The [`explicit-module-boundary-types`](https://typescript-eslint.io/rules/explicit-module-boundary-types/) lint isn't part of `strict-type-checked`, but it's also explicitly disabled in a bunch of places https://github.com/cosmos/cosmjs/commit/11ec6f1393534b68e9abbe07b4bce7d48edfdc15 and wasn't actually enabled anywhere.

Maybe they were enabled in an older version of the eslint plugin before the updates.