### PR TITLE
Remove extra RPC call for version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
   `Tendermint34Client.create`, `Tendermint37Client.create` and
   `Comet38Client.create` non-async. ([#1597])
 - @cosmjs/tendermint-rpc, @cosmjs/faucet-client: Remove cross-fetch polyfilling.
+- @cosmjs/tendermint-rpc: Avoid unnecessary status request when connecting a
+  `Comet38Client`, `Tendermint37Client` or `Tendermint34Client`. ([#1772])
 - @cosmjs/stargate: Make constructor functions `{Signing,}StargateClient.create`
   and `SigningStargateClient.createWithSigner` non-async. ([#1597])
 - @cosmjs/cosmwasm: Make constructor functions `{Signing,}CosmWasmClient.create`
@@ -36,6 +38,7 @@ and this project adheres to
 [#1720]: https://github.com/cosmos/cosmjs/pull/1720
 [#1761]: https://github.com/cosmos/cosmjs/pull/1761
 [#1763]: https://github.com/cosmos/cosmjs/pull/1763
+[#1772]: https://github.com/cosmos/cosmjs/pull/1772
 
 ## [0.34.0] - 2025-07-11
 

--- a/packages/tendermint-rpc/src/comet38/comet38client.ts
+++ b/packages/tendermint-rpc/src/comet38/comet38client.ts
@@ -37,13 +37,6 @@ export class Comet38Client {
       const useHttp = endpoint.startsWith("http://") || endpoint.startsWith("https://");
       rpcClient = useHttp ? new HttpClient(endpoint) : new WebsocketClient(endpoint);
     }
-
-    // For some very strange reason I don't understand, tests start to fail on some systems
-    // (our CI) when skipping the status call before doing other queries. Sleeping a little
-    // while did not help. Thus we query the version as a way to say "hi" to the backend,
-    // even in cases where we don't use the result.
-    const _version = await this.detectVersion(rpcClient);
-
     return Comet38Client.create(rpcClient);
   }
 

--- a/packages/tendermint-rpc/src/comet38/comet38client.ts
+++ b/packages/tendermint-rpc/src/comet38/comet38client.ts
@@ -1,7 +1,6 @@
 import { JsonRpcRequest, JsonRpcSuccessResponse } from "@cosmjs/json-rpc";
 import { Stream } from "xstream";
 
-import { createJsonRpcRequest } from "../jsonrpc";
 import {
   HttpClient,
   HttpEndpoint,
@@ -45,22 +44,6 @@ export class Comet38Client {
    */
   public static create(rpcClient: RpcClient): Comet38Client {
     return new Comet38Client(rpcClient);
-  }
-
-  private static async detectVersion(client: RpcClient): Promise<string> {
-    const req = createJsonRpcRequest(requests.Method.Status);
-    const response = await client.execute(req);
-    const result = response.result;
-
-    if (!result || !result.node_info) {
-      throw new Error("Unrecognized format for status response");
-    }
-
-    const version = result.node_info.version;
-    if (typeof version !== "string") {
-      throw new Error("Unrecognized version format: must be string");
-    }
-    return version;
   }
 
   private readonly client: RpcClient;

--- a/packages/tendermint-rpc/src/tendermint34/tendermint34client.ts
+++ b/packages/tendermint-rpc/src/tendermint34/tendermint34client.ts
@@ -1,7 +1,6 @@
 import { JsonRpcRequest, JsonRpcSuccessResponse } from "@cosmjs/json-rpc";
 import { Stream } from "xstream";
 
-import { createJsonRpcRequest } from "../jsonrpc";
 import {
   HttpClient,
   HttpEndpoint,
@@ -42,22 +41,6 @@ export class Tendermint34Client {
    */
   public static create(rpcClient: RpcClient): Tendermint34Client {
     return new Tendermint34Client(rpcClient);
-  }
-
-  private static async detectVersion(client: RpcClient): Promise<string> {
-    const req = createJsonRpcRequest(requests.Method.Status);
-    const response = await client.execute(req);
-    const result = response.result;
-
-    if (!result || !result.node_info) {
-      throw new Error("Unrecognized format for status response");
-    }
-
-    const version = result.node_info.version;
-    if (typeof version !== "string") {
-      throw new Error("Unrecognized version format: must be string");
-    }
-    return version;
   }
 
   private readonly client: RpcClient;

--- a/packages/tendermint-rpc/src/tendermint34/tendermint34client.ts
+++ b/packages/tendermint-rpc/src/tendermint34/tendermint34client.ts
@@ -34,13 +34,6 @@ export class Tendermint34Client {
       const useHttp = endpoint.startsWith("http://") || endpoint.startsWith("https://");
       rpcClient = useHttp ? new HttpClient(endpoint) : new WebsocketClient(endpoint);
     }
-
-    // For some very strange reason I don't understand, tests start to fail on some systems
-    // (our CI) when skipping the status call before doing other queries. Sleeping a little
-    // while did not help. Thus we query the version as a way to say "hi" to the backend,
-    // even in cases where we don't use the result.
-    const _version = await this.detectVersion(rpcClient);
-
     return Tendermint34Client.create(rpcClient);
   }
 

--- a/packages/tendermint-rpc/src/tendermint37/tendermint37client.ts
+++ b/packages/tendermint-rpc/src/tendermint37/tendermint37client.ts
@@ -1,7 +1,6 @@
 import { JsonRpcRequest, JsonRpcSuccessResponse } from "@cosmjs/json-rpc";
 import { Stream } from "xstream";
 
-import { createJsonRpcRequest } from "../jsonrpc";
 import {
   HttpClient,
   HttpEndpoint,
@@ -42,22 +41,6 @@ export class Tendermint37Client {
    */
   public static create(rpcClient: RpcClient): Tendermint37Client {
     return new Tendermint37Client(rpcClient);
-  }
-
-  private static async detectVersion(client: RpcClient): Promise<string> {
-    const req = createJsonRpcRequest(requests.Method.Status);
-    const response = await client.execute(req);
-    const result = response.result;
-
-    if (!result || !result.node_info) {
-      throw new Error("Unrecognized format for status response");
-    }
-
-    const version = result.node_info.version;
-    if (typeof version !== "string") {
-      throw new Error("Unrecognized version format: must be string");
-    }
-    return version;
   }
 
   private readonly client: RpcClient;

--- a/packages/tendermint-rpc/src/tendermint37/tendermint37client.ts
+++ b/packages/tendermint-rpc/src/tendermint37/tendermint37client.ts
@@ -34,13 +34,6 @@ export class Tendermint37Client {
       const useHttp = endpoint.startsWith("http://") || endpoint.startsWith("https://");
       rpcClient = useHttp ? new HttpClient(endpoint) : new WebsocketClient(endpoint);
     }
-
-    // For some very strange reason I don't understand, tests start to fail on some systems
-    // (our CI) when skipping the status call before doing other queries. Sleeping a little
-    // while did not help. Thus we query the version as a way to say "hi" to the backend,
-    // even in cases where we don't use the result.
-    const _version = await this.detectVersion(rpcClient);
-
     return Tendermint37Client.create(rpcClient);
   }
 


### PR DESCRIPTION
Turns out that the extra RPC request is not needed anymore to make things work after migrating to GitHub Actions. No idea, but it's actually great.

Closes #1773
Closes #1607