### PR TITLE
fix: correct typos in decimal constructor docs and pubkey conversion comment

### DIFF
--- a/packages/math/src/decimal.ts
+++ b/packages/math/src/decimal.ts
@@ -60,7 +60,7 @@ export class Decimal {
   }
 
   /**
-   * Creates a Decimal with value 0.0 and the given number of fractial digits.
+   * Creates a Decimal with value 0.0 and the given number of fractional digits.
    *
    * Fractional digits are not relevant for the value but needed to be able
    * to perform arithmetic operations with other decimals.
@@ -71,7 +71,7 @@ export class Decimal {
   }
 
   /**
-   * Creates a Decimal with value 1.0 and the given number of fractial digits.
+   * Creates a Decimal with value 1.0 and the given number of fractional digits.
    *
    * Fractional digits are not relevant for the value but needed to be able
    * to perform arithmetic operations with other decimals.

--- a/packages/proto-signing/src/pubkey.ts
+++ b/packages/proto-signing/src/pubkey.ts
@@ -17,7 +17,7 @@ import { Any } from "cosmjs-types/google/protobuf/any";
 
 /**
  * Takes a pubkey in the Amino JSON object style (type/value wrapper)
- * and convertes it into a protobuf `Any`.
+ * and converts it into a protobuf `Any`.
  *
  * This is the reverse operation to `decodePubkey`.
  */


### PR DESCRIPTION
Fixed typo “fractial” → “fractional” in Decimal class documentation (two occurrences).

Fixed typo “convertes” → “converts” in pubkey.ts comment.