### PR TITLE
import cosmjs-types with full file path

### DIFF
--- a/packages/cosmwasm-stargate/src/cosmwasmclient.searchtx.spec.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.searchtx.spec.ts
@@ -17,7 +17,7 @@ import {
   isMsgSendEncodeObject,
 } from "@cosmjs/stargate";
 import { assert, sleep } from "@cosmjs/utils";
-import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
 
 import { CosmWasmClient } from "./cosmwasmclient";
 import {

--- a/packages/cosmwasm-stargate/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "@cosmjs/proto-signing";
 import { assertIsDeliverTxSuccess, coins, MsgSendEncodeObject, StdFee } from "@cosmjs/stargate";
 import { assert, sleep } from "@cosmjs/utils";
-import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
 import { ReadonlyDate } from "readonly-date";
 
 import { Code, CosmWasmClient, PrivateCosmWasmClient } from "./cosmwasmclient";

--- a/packages/cosmwasm-stargate/src/cosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/cosmwasmclient.ts
@@ -23,14 +23,14 @@ import {
 } from "@cosmjs/stargate";
 import { CometClient, connectComet, HttpEndpoint, toRfc3339WithNanoseconds } from "@cosmjs/tendermint-rpc";
 import { assert, sleep } from "@cosmjs/utils";
-import { TxMsgData } from "cosmjs-types/cosmos/base/abci/v1beta1/abci";
+import { TxMsgData } from "cosmjs-types/cosmos/base/abci/v1beta1/abci.js";
 import {
   CodeInfoResponse,
   QueryCodesResponse,
   QueryContractsByCodeResponse,
   QueryContractsByCreatorResponse,
-} from "cosmjs-types/cosmwasm/wasm/v1/query";
-import { ContractCodeHistoryOperationType } from "cosmjs-types/cosmwasm/wasm/v1/types";
+} from "cosmjs-types/cosmwasm/wasm/v1/query.js";
+import { ContractCodeHistoryOperationType } from "cosmjs-types/cosmwasm/wasm/v1/types.js";
 
 import { JsonObject, setupWasmExtension, WasmExtension } from "./modules";
 

--- a/packages/cosmwasm-stargate/src/modules/wasm/aminomessages.spec.ts
+++ b/packages/cosmwasm-stargate/src/modules/wasm/aminomessages.spec.ts
@@ -8,8 +8,8 @@ import {
   MsgMigrateContract,
   MsgStoreCode,
   MsgUpdateAdmin,
-} from "cosmjs-types/cosmwasm/wasm/v1/tx";
-import { AccessType } from "cosmjs-types/cosmwasm/wasm/v1/types";
+} from "cosmjs-types/cosmwasm/wasm/v1/tx.js";
+import { AccessType } from "cosmjs-types/cosmwasm/wasm/v1/types.js";
 
 import {
   AminoMsgClearAdmin,

--- a/packages/cosmwasm-stargate/src/modules/wasm/aminomessages.ts
+++ b/packages/cosmwasm-stargate/src/modules/wasm/aminomessages.ts
@@ -10,8 +10,8 @@ import {
   MsgMigrateContract,
   MsgStoreCode,
   MsgUpdateAdmin,
-} from "cosmjs-types/cosmwasm/wasm/v1/tx";
-import { AccessConfig, AccessType } from "cosmjs-types/cosmwasm/wasm/v1/types";
+} from "cosmjs-types/cosmwasm/wasm/v1/tx.js";
+import { AccessConfig, AccessType } from "cosmjs-types/cosmwasm/wasm/v1/types.js";
 
 export function accessTypeFromString(str: string): AccessType {
   switch (str) {

--- a/packages/cosmwasm-stargate/src/modules/wasm/messages.ts
+++ b/packages/cosmwasm-stargate/src/modules/wasm/messages.ts
@@ -7,7 +7,7 @@ import {
   MsgMigrateContract,
   MsgStoreCode,
   MsgUpdateAdmin,
-} from "cosmjs-types/cosmwasm/wasm/v1/tx";
+} from "cosmjs-types/cosmwasm/wasm/v1/tx.js";
 
 export const wasmTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/cosmwasm.wasm.v1.MsgClearAdmin", MsgClearAdmin],

--- a/packages/cosmwasm-stargate/src/modules/wasm/queries.spec.ts
+++ b/packages/cosmwasm-stargate/src/modules/wasm/queries.spec.ts
@@ -11,8 +11,12 @@ import {
   StdFee,
 } from "@cosmjs/stargate";
 import { assert, assertDefined } from "@cosmjs/utils";
-import { MsgExecuteContract, MsgInstantiateContract, MsgStoreCode } from "cosmjs-types/cosmwasm/wasm/v1/tx";
-import { AbsoluteTxPosition, ContractCodeHistoryOperationType } from "cosmjs-types/cosmwasm/wasm/v1/types";
+import {
+  MsgExecuteContract,
+  MsgInstantiateContract,
+  MsgStoreCode,
+} from "cosmjs-types/cosmwasm/wasm/v1/tx.js";
+import { AbsoluteTxPosition, ContractCodeHistoryOperationType } from "cosmjs-types/cosmwasm/wasm/v1/types.js";
 
 import { findAttribute, SigningCosmWasmClient } from "../../signingcosmwasmclient";
 import {

--- a/packages/cosmwasm-stargate/src/modules/wasm/queries.ts
+++ b/packages/cosmwasm-stargate/src/modules/wasm/queries.ts
@@ -12,7 +12,7 @@ import {
   QueryContractsByCodeResponse,
   QueryContractsByCreatorResponse,
   QueryRawContractStateResponse,
-} from "cosmjs-types/cosmwasm/wasm/v1/query";
+} from "cosmjs-types/cosmwasm/wasm/v1/query.js";
 
 /**
  * An object containing a parsed JSON document. The result of JSON.parse().

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.spec.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.spec.ts
@@ -15,13 +15,13 @@ import {
 } from "@cosmjs/stargate";
 import { assert, sleep } from "@cosmjs/utils";
 import { DeepPartial } from "cosmjs-types";
-import { BinaryWriter } from "cosmjs-types/binary";
-import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
-import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
-import { MsgDelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
-import { AuthInfo, TxBody, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
-import { MsgExecuteContract, MsgStoreCode } from "cosmjs-types/cosmwasm/wasm/v1/tx";
-import { AccessConfig, AccessType } from "cosmjs-types/cosmwasm/wasm/v1/types";
+import { BinaryWriter } from "cosmjs-types/binary.js";
+import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx.js";
+import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin.js";
+import { MsgDelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx.js";
+import { AuthInfo, TxBody, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
+import { MsgExecuteContract, MsgStoreCode } from "cosmjs-types/cosmwasm/wasm/v1/tx.js";
+import { AccessConfig, AccessType } from "cosmjs-types/cosmwasm/wasm/v1/types.js";
 import { gzip } from "pako";
 
 import { instantiate2Address } from "./instantiate2";

--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts
@@ -33,10 +33,10 @@ import {
 } from "@cosmjs/stargate";
 import { CometClient, connectComet, HttpEndpoint } from "@cosmjs/tendermint-rpc";
 import { assert, assertDefined } from "@cosmjs/utils";
-import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
-import { MsgDelegate, MsgUndelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
-import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
-import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx.js";
+import { MsgDelegate, MsgUndelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx.js";
+import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing.js";
+import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
 import {
   MsgClearAdmin,
   MsgExecuteContract,
@@ -45,8 +45,8 @@ import {
   MsgMigrateContract,
   MsgStoreCode,
   MsgUpdateAdmin,
-} from "cosmjs-types/cosmwasm/wasm/v1/tx";
-import { AccessConfig } from "cosmjs-types/cosmwasm/wasm/v1/types";
+} from "cosmjs-types/cosmwasm/wasm/v1/tx.js";
+import { AccessConfig } from "cosmjs-types/cosmwasm/wasm/v1/types.js";
 import { gzip } from "pako";
 
 import { CosmWasmClient } from "./cosmwasmclient";

--- a/packages/cosmwasm-stargate/src/testutils.spec.ts
+++ b/packages/cosmwasm-stargate/src/testutils.spec.ts
@@ -19,8 +19,8 @@ import {
 } from "@cosmjs/stargate";
 import { connectComet } from "@cosmjs/tendermint-rpc";
 import { assertDefinedAndNotNull } from "@cosmjs/utils";
-import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
-import { AuthInfo, SignDoc, TxBody } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing.js";
+import { AuthInfo, SignDoc, TxBody } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
 
 import { setupWasmExtension, WasmExtension } from "./modules";
 import { SigningCosmWasmClientOptions } from "./signingcosmwasmclient";

--- a/packages/proto-signing/src/decode.spec.ts
+++ b/packages/proto-signing/src/decode.spec.ts
@@ -1,8 +1,8 @@
 import { fromBase64, fromHex } from "@cosmjs/encoding";
-import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
-import { PubKey } from "cosmjs-types/cosmos/crypto/secp256k1/keys";
-import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx.js";
+import { PubKey } from "cosmjs-types/cosmos/crypto/secp256k1/keys.js";
+import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing.js";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 
 import { decodeTxRaw } from "./decode";
 import { faucet, testVectors } from "./testutils.spec";

--- a/packages/proto-signing/src/decode.ts
+++ b/packages/proto-signing/src/decode.ts
@@ -1,4 +1,4 @@
-import { AuthInfo, TxBody, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { AuthInfo, TxBody, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
 
 export interface DecodedTxRaw {
   readonly authInfo: AuthInfo;

--- a/packages/proto-signing/src/directsecp256k1hdwallet.ts
+++ b/packages/proto-signing/src/directsecp256k1hdwallet.ts
@@ -14,7 +14,7 @@ import {
 } from "@cosmjs/crypto";
 import { fromBase64, fromUtf8, toBase64, toBech32, toUtf8 } from "@cosmjs/encoding";
 import { assert, isNonNullObject } from "@cosmjs/utils";
-import { SignDoc } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { SignDoc } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
 
 import { AccountData, DirectSignResponse, OfflineDirectSigner } from "./signer";
 import { makeSignBytes } from "./signing";

--- a/packages/proto-signing/src/directsecp256k1wallet.ts
+++ b/packages/proto-signing/src/directsecp256k1wallet.ts
@@ -1,7 +1,7 @@
 import { encodeSecp256k1Signature, rawSecp256k1PubkeyToRawAddress } from "@cosmjs/amino";
 import { Secp256k1, sha256 } from "@cosmjs/crypto";
 import { toBech32 } from "@cosmjs/encoding";
-import { SignDoc } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { SignDoc } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
 
 import { AccountData, DirectSignResponse, OfflineDirectSigner } from "./signer";
 import { makeSignBytes } from "./signing";

--- a/packages/proto-signing/src/pubkey.spec.ts
+++ b/packages/proto-signing/src/pubkey.spec.ts
@@ -1,5 +1,5 @@
 import { fromBase64 } from "@cosmjs/encoding";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 
 import { decodePubkey, encodePubkey } from "./pubkey";
 

--- a/packages/proto-signing/src/pubkey.ts
+++ b/packages/proto-signing/src/pubkey.ts
@@ -10,10 +10,10 @@ import {
 } from "@cosmjs/amino";
 import { fromBase64 } from "@cosmjs/encoding";
 import { Uint53 } from "@cosmjs/math";
-import { PubKey as CosmosCryptoEd25519Pubkey } from "cosmjs-types/cosmos/crypto/ed25519/keys";
-import { LegacyAminoPubKey } from "cosmjs-types/cosmos/crypto/multisig/keys";
-import { PubKey as CosmosCryptoSecp256k1Pubkey } from "cosmjs-types/cosmos/crypto/secp256k1/keys";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import { PubKey as CosmosCryptoEd25519Pubkey } from "cosmjs-types/cosmos/crypto/ed25519/keys.js";
+import { LegacyAminoPubKey } from "cosmjs-types/cosmos/crypto/multisig/keys.js";
+import { PubKey as CosmosCryptoSecp256k1Pubkey } from "cosmjs-types/cosmos/crypto/secp256k1/keys.js";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 
 /**
  * Takes a pubkey in the Amino JSON object style (type/value wrapper)

--- a/packages/proto-signing/src/registry.spec.ts
+++ b/packages/proto-signing/src/registry.spec.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { fromHex } from "@cosmjs/encoding";
 import { assert } from "@cosmjs/utils";
-import { MsgSend as IMsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
-import { TxBody } from "cosmjs-types/cosmos/tx/v1beta1/tx";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import { MsgSend as IMsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx.js";
+import { TxBody } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 import { Field, Type } from "protobufjs";
 
 import { isPbjsGeneratedType, isTsProtoGeneratedType, Registry } from "./registry";

--- a/packages/proto-signing/src/registry.ts
+++ b/packages/proto-signing/src/registry.ts
@@ -1,8 +1,8 @@
-import { BinaryWriter } from "cosmjs-types/binary";
-import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
-import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
-import { TxBody } from "cosmjs-types/cosmos/tx/v1beta1/tx";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import { BinaryWriter } from "cosmjs-types/binary.js";
+import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx.js";
+import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin.js";
+import { TxBody } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 import type protobuf from "protobufjs";
 
 /**

--- a/packages/proto-signing/src/signer.ts
+++ b/packages/proto-signing/src/signer.ts
@@ -1,5 +1,5 @@
 import { OfflineAminoSigner, StdSignature } from "@cosmjs/amino";
-import { SignDoc } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { SignDoc } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
 
 export type Algo = "secp256k1" | "ed25519" | "sr25519";
 export interface AccountData {

--- a/packages/proto-signing/src/signing.spec.ts
+++ b/packages/proto-signing/src/signing.spec.ts
@@ -1,7 +1,7 @@
 import { fromBase64, fromHex, toHex } from "@cosmjs/encoding";
-import { PubKey } from "cosmjs-types/cosmos/crypto/secp256k1/keys";
-import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
-import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { PubKey } from "cosmjs-types/cosmos/crypto/secp256k1/keys.js";
+import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing.js";
+import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
 
 import { decodeTxRaw } from "./decode";
 import { DirectSecp256k1HdWallet } from "./directsecp256k1hdwallet";

--- a/packages/proto-signing/src/signing.ts
+++ b/packages/proto-signing/src/signing.ts
@@ -1,8 +1,8 @@
 import { assert } from "@cosmjs/utils";
-import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
-import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
-import { AuthInfo, SignDoc, SignerInfo } from "cosmjs-types/cosmos/tx/v1beta1/tx";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin.js";
+import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing.js";
+import { AuthInfo, SignDoc, SignerInfo } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 
 /**
  * Create signer infos from the provided signers.

--- a/packages/stargate/src/accounts.spec.ts
+++ b/packages/stargate/src/accounts.spec.ts
@@ -1,5 +1,5 @@
 import { fromBase64 } from "@cosmjs/encoding";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 
 import { accountFromAny } from "./accounts";
 

--- a/packages/stargate/src/accounts.ts
+++ b/packages/stargate/src/accounts.ts
@@ -2,14 +2,14 @@ import { Pubkey } from "@cosmjs/amino";
 import { Uint64 } from "@cosmjs/math";
 import { decodeOptionalPubkey } from "@cosmjs/proto-signing";
 import { assert } from "@cosmjs/utils";
-import { BaseAccount, ModuleAccount } from "cosmjs-types/cosmos/auth/v1beta1/auth";
+import { BaseAccount, ModuleAccount } from "cosmjs-types/cosmos/auth/v1beta1/auth.js";
 import {
   BaseVestingAccount,
   ContinuousVestingAccount,
   DelayedVestingAccount,
   PeriodicVestingAccount,
-} from "cosmjs-types/cosmos/vesting/v1beta1/vesting";
-import { Any } from "cosmjs-types/google/protobuf/any";
+} from "cosmjs-types/cosmos/vesting/v1beta1/vesting.js";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 
 export interface Account {
   /** Bech32 account address */

--- a/packages/stargate/src/aminotypes.spec.ts
+++ b/packages/stargate/src/aminotypes.spec.ts
@@ -1,5 +1,5 @@
 import { coin } from "@cosmjs/proto-signing";
-import { MsgDelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
+import { MsgDelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx.js";
 
 import { AminoTypes } from "./aminotypes";
 import { createBankAminoConverters, createStakingAminoConverters } from "./modules";

--- a/packages/stargate/src/modules/auth/queries.spec.ts
+++ b/packages/stargate/src/modules/auth/queries.spec.ts
@@ -1,8 +1,8 @@
 import { encodePubkey } from "@cosmjs/proto-signing";
 import { CometClient, connectComet } from "@cosmjs/tendermint-rpc";
 import { assert } from "@cosmjs/utils";
-import { BaseAccount } from "cosmjs-types/cosmos/auth/v1beta1/auth";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import { BaseAccount } from "cosmjs-types/cosmos/auth/v1beta1/auth.js";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 
 import { QueryClient } from "../../queryclient";
 import { nonExistentAddress, pendingWithoutSimapp, simapp, unused, validator } from "../../testutils.spec";

--- a/packages/stargate/src/modules/auth/queries.ts
+++ b/packages/stargate/src/modules/auth/queries.ts
@@ -1,5 +1,5 @@
-import { QueryClientImpl } from "cosmjs-types/cosmos/auth/v1beta1/query";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import { QueryClientImpl } from "cosmjs-types/cosmos/auth/v1beta1/query.js";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 
 import { createProtobufRpcClient, QueryClient } from "../../queryclient";
 

--- a/packages/stargate/src/modules/authz/messages.ts
+++ b/packages/stargate/src/modules/authz/messages.ts
@@ -1,5 +1,5 @@
 import { GeneratedType } from "@cosmjs/proto-signing";
-import { MsgExec, MsgGrant, MsgRevoke } from "cosmjs-types/cosmos/authz/v1beta1/tx";
+import { MsgExec, MsgGrant, MsgRevoke } from "cosmjs-types/cosmos/authz/v1beta1/tx.js";
 
 export const authzTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/cosmos.authz.v1beta1.MsgExec", MsgExec],

--- a/packages/stargate/src/modules/authz/queries.spec.ts
+++ b/packages/stargate/src/modules/authz/queries.spec.ts
@@ -2,7 +2,7 @@ import { makeCosmoshubPath } from "@cosmjs/amino";
 import { coins, DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import { CometClient, connectComet } from "@cosmjs/tendermint-rpc";
 import { assertDefined, sleep } from "@cosmjs/utils";
-import { GenericAuthorization } from "cosmjs-types/cosmos/authz/v1beta1/authz";
+import { GenericAuthorization } from "cosmjs-types/cosmos/authz/v1beta1/authz.js";
 
 import { QueryClient } from "../../queryclient";
 import { SigningStargateClient } from "../../signingstargateclient";

--- a/packages/stargate/src/modules/authz/queries.ts
+++ b/packages/stargate/src/modules/authz/queries.ts
@@ -3,7 +3,7 @@ import {
   QueryGranteeGrantsResponse,
   QueryGranterGrantsResponse,
   QueryGrantsResponse,
-} from "cosmjs-types/cosmos/authz/v1beta1/query";
+} from "cosmjs-types/cosmos/authz/v1beta1/query.js";
 
 import { createPagination, createProtobufRpcClient, QueryClient } from "../../queryclient";
 

--- a/packages/stargate/src/modules/bank/aminomessages.spec.ts
+++ b/packages/stargate/src/modules/bank/aminomessages.spec.ts
@@ -1,5 +1,5 @@
 import { coins } from "@cosmjs/proto-signing";
-import { MsgMultiSend, MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
+import { MsgMultiSend, MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx.js";
 
 import { AminoTypes } from "../../aminotypes";
 import { AminoMsgMultiSend, AminoMsgSend, createBankAminoConverters } from "./aminomessages";

--- a/packages/stargate/src/modules/bank/aminomessages.ts
+++ b/packages/stargate/src/modules/bank/aminomessages.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { AminoMsg, Coin } from "@cosmjs/amino";
-import { MsgMultiSend, MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
+import { MsgMultiSend, MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx.js";
 
 import { AminoConverters } from "../../aminotypes";
 

--- a/packages/stargate/src/modules/bank/messages.ts
+++ b/packages/stargate/src/modules/bank/messages.ts
@@ -1,5 +1,5 @@
 import { EncodeObject, GeneratedType } from "@cosmjs/proto-signing";
-import { MsgMultiSend, MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
+import { MsgMultiSend, MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx.js";
 
 export const bankTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/cosmos.bank.v1beta1.MsgMultiSend", MsgMultiSend],

--- a/packages/stargate/src/modules/bank/queries.ts
+++ b/packages/stargate/src/modules/bank/queries.ts
@@ -1,12 +1,12 @@
 import { assert } from "@cosmjs/utils";
-import { Metadata } from "cosmjs-types/cosmos/bank/v1beta1/bank";
+import { Metadata } from "cosmjs-types/cosmos/bank/v1beta1/bank.js";
 import {
   QueryAllBalancesRequest,
   QueryClientImpl,
   QueryDenomsMetadataRequest,
   QueryTotalSupplyResponse,
-} from "cosmjs-types/cosmos/bank/v1beta1/query";
-import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
+} from "cosmjs-types/cosmos/bank/v1beta1/query.js";
+import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin.js";
 
 import { createPagination, createProtobufRpcClient, QueryClient } from "../../queryclient";
 

--- a/packages/stargate/src/modules/distribution/aminomessages.spec.ts
+++ b/packages/stargate/src/modules/distribution/aminomessages.spec.ts
@@ -4,7 +4,7 @@ import {
   MsgSetWithdrawAddress,
   MsgWithdrawDelegatorReward,
   MsgWithdrawValidatorCommission,
-} from "cosmjs-types/cosmos/distribution/v1beta1/tx";
+} from "cosmjs-types/cosmos/distribution/v1beta1/tx.js";
 
 import { AminoTypes } from "../../aminotypes";
 import {

--- a/packages/stargate/src/modules/distribution/aminomessages.ts
+++ b/packages/stargate/src/modules/distribution/aminomessages.ts
@@ -5,7 +5,7 @@ import {
   MsgSetWithdrawAddress,
   MsgWithdrawDelegatorReward,
   MsgWithdrawValidatorCommission,
-} from "cosmjs-types/cosmos/distribution/v1beta1/tx";
+} from "cosmjs-types/cosmos/distribution/v1beta1/tx.js";
 
 import { AminoConverter } from "../..";
 

--- a/packages/stargate/src/modules/distribution/messages.ts
+++ b/packages/stargate/src/modules/distribution/messages.ts
@@ -4,7 +4,7 @@ import {
   MsgSetWithdrawAddress,
   MsgWithdrawDelegatorReward,
   MsgWithdrawValidatorCommission,
-} from "cosmjs-types/cosmos/distribution/v1beta1/tx";
+} from "cosmjs-types/cosmos/distribution/v1beta1/tx.js";
 
 export const distributionTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/cosmos.distribution.v1beta1.MsgFundCommunityPool", MsgFundCommunityPool],

--- a/packages/stargate/src/modules/distribution/queries.spec.ts
+++ b/packages/stargate/src/modules/distribution/queries.spec.ts
@@ -1,7 +1,7 @@
 import { coin, coins, DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import { CometClient, connectComet } from "@cosmjs/tendermint-rpc";
 import { sleep } from "@cosmjs/utils";
-import { MsgDelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
+import { MsgDelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx.js";
 
 import { QueryClient } from "../../queryclient";
 import { SigningStargateClient } from "../../signingstargateclient";

--- a/packages/stargate/src/modules/distribution/queries.ts
+++ b/packages/stargate/src/modules/distribution/queries.ts
@@ -9,7 +9,7 @@ import {
   QueryValidatorCommissionResponse,
   QueryValidatorOutstandingRewardsResponse,
   QueryValidatorSlashesResponse,
-} from "cosmjs-types/cosmos/distribution/v1beta1/query";
+} from "cosmjs-types/cosmos/distribution/v1beta1/query.js";
 
 import { createPagination, createProtobufRpcClient, QueryClient } from "../../queryclient";
 

--- a/packages/stargate/src/modules/feegrant/messages.ts
+++ b/packages/stargate/src/modules/feegrant/messages.ts
@@ -1,5 +1,5 @@
 import { GeneratedType } from "@cosmjs/proto-signing";
-import { MsgGrantAllowance, MsgRevokeAllowance } from "cosmjs-types/cosmos/feegrant/v1beta1/tx";
+import { MsgGrantAllowance, MsgRevokeAllowance } from "cosmjs-types/cosmos/feegrant/v1beta1/tx.js";
 
 export const feegrantTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/cosmos.feegrant.v1beta1.MsgGrantAllowance", MsgGrantAllowance],

--- a/packages/stargate/src/modules/feegrant/queries.ts
+++ b/packages/stargate/src/modules/feegrant/queries.ts
@@ -2,7 +2,7 @@ import {
   QueryAllowanceResponse,
   QueryAllowancesResponse,
   QueryClientImpl,
-} from "cosmjs-types/cosmos/feegrant/v1beta1/query";
+} from "cosmjs-types/cosmos/feegrant/v1beta1/query.js";
 
 import { createPagination, createProtobufRpcClient, QueryClient } from "../../queryclient";
 

--- a/packages/stargate/src/modules/gov/aminomessages.spec.ts
+++ b/packages/stargate/src/modules/gov/aminomessages.spec.ts
@@ -1,5 +1,10 @@
-import { TextProposal, VoteOption } from "cosmjs-types/cosmos/gov/v1beta1/gov";
-import { MsgDeposit, MsgSubmitProposal, MsgVote, MsgVoteWeighted } from "cosmjs-types/cosmos/gov/v1beta1/tx";
+import { TextProposal, VoteOption } from "cosmjs-types/cosmos/gov/v1beta1/gov.js";
+import {
+  MsgDeposit,
+  MsgSubmitProposal,
+  MsgVote,
+  MsgVoteWeighted,
+} from "cosmjs-types/cosmos/gov/v1beta1/tx.js";
 
 import { AminoTypes } from "../../aminotypes";
 import {

--- a/packages/stargate/src/modules/gov/aminomessages.ts
+++ b/packages/stargate/src/modules/gov/aminomessages.ts
@@ -2,9 +2,14 @@
 import { AminoMsg, Coin } from "@cosmjs/amino";
 import { Decimal } from "@cosmjs/math";
 import { assert, assertDefinedAndNotNull, isNonNullObject } from "@cosmjs/utils";
-import { TextProposal, voteOptionFromJSON } from "cosmjs-types/cosmos/gov/v1beta1/gov";
-import { MsgDeposit, MsgSubmitProposal, MsgVote, MsgVoteWeighted } from "cosmjs-types/cosmos/gov/v1beta1/tx";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import { TextProposal, voteOptionFromJSON } from "cosmjs-types/cosmos/gov/v1beta1/gov.js";
+import {
+  MsgDeposit,
+  MsgSubmitProposal,
+  MsgVote,
+  MsgVoteWeighted,
+} from "cosmjs-types/cosmos/gov/v1beta1/tx.js";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 
 import { AminoConverters } from "../../aminotypes";
 import { decodeCosmosSdkDecFromProto } from "../../queryclient";

--- a/packages/stargate/src/modules/gov/messages.spec.ts
+++ b/packages/stargate/src/modules/gov/messages.spec.ts
@@ -1,8 +1,8 @@
 import { coin, coins, makeCosmoshubPath, Secp256k1HdWallet } from "@cosmjs/amino";
 import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import { assert, sleep } from "@cosmjs/utils";
-import { TextProposal, VoteOption } from "cosmjs-types/cosmos/gov/v1beta1/gov";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import { TextProposal, VoteOption } from "cosmjs-types/cosmos/gov/v1beta1/gov.js";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 
 import { longify } from "../../queryclient";
 import { SigningStargateClient } from "../../signingstargateclient";

--- a/packages/stargate/src/modules/gov/messages.ts
+++ b/packages/stargate/src/modules/gov/messages.ts
@@ -5,8 +5,13 @@ import {
   MsgUpdateParams as V1MsgUpdateParams,
   MsgVote as V1MsgVote,
   MsgVoteWeighted as V1MsgVoteWeighted,
-} from "cosmjs-types/cosmos/gov/v1/tx";
-import { MsgDeposit, MsgSubmitProposal, MsgVote, MsgVoteWeighted } from "cosmjs-types/cosmos/gov/v1beta1/tx";
+} from "cosmjs-types/cosmos/gov/v1/tx.js";
+import {
+  MsgDeposit,
+  MsgSubmitProposal,
+  MsgVote,
+  MsgVoteWeighted,
+} from "cosmjs-types/cosmos/gov/v1beta1/tx.js";
 
 export const govTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/cosmos.gov.v1.MsgDeposit", V1MsgDeposit],

--- a/packages/stargate/src/modules/gov/queries.spec.ts
+++ b/packages/stargate/src/modules/gov/queries.spec.ts
@@ -9,8 +9,8 @@ import {
   Vote,
   VoteOption,
   WeightedVoteOption,
-} from "cosmjs-types/cosmos/gov/v1beta1/gov";
-import { Any } from "cosmjs-types/google/protobuf/any";
+} from "cosmjs-types/cosmos/gov/v1beta1/gov.js";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 
 import { longify, QueryClient } from "../../queryclient";
 import { SigningStargateClient } from "../../signingstargateclient";

--- a/packages/stargate/src/modules/gov/queries.ts
+++ b/packages/stargate/src/modules/gov/queries.ts
@@ -1,5 +1,5 @@
 import { Uint64 } from "@cosmjs/math";
-import { ProposalStatus } from "cosmjs-types/cosmos/gov/v1beta1/gov";
+import { ProposalStatus } from "cosmjs-types/cosmos/gov/v1beta1/gov.js";
 import {
   QueryClientImpl,
   QueryDepositResponse,
@@ -10,7 +10,7 @@ import {
   QueryTallyResultResponse,
   QueryVoteResponse,
   QueryVotesResponse,
-} from "cosmjs-types/cosmos/gov/v1beta1/query";
+} from "cosmjs-types/cosmos/gov/v1beta1/query.js";
 
 import { createPagination, createProtobufRpcClient, longify, QueryClient } from "../../queryclient";
 

--- a/packages/stargate/src/modules/group/messages.ts
+++ b/packages/stargate/src/modules/group/messages.ts
@@ -14,7 +14,7 @@ import {
   MsgUpdateGroupPolicyMetadata,
   MsgVote,
   MsgWithdrawProposal,
-} from "cosmjs-types/cosmos/group/v1/tx";
+} from "cosmjs-types/cosmos/group/v1/tx.js";
 
 export const groupTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/cosmos.group.v1.MsgCreateGroup", MsgCreateGroup],

--- a/packages/stargate/src/modules/ibc/aminomessages.spec.ts
+++ b/packages/stargate/src/modules/ibc/aminomessages.spec.ts
@@ -1,5 +1,5 @@
 import { coin } from "@cosmjs/proto-signing";
-import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
+import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx.js";
 
 import { AminoTypes } from "../../aminotypes";
 import { AminoMsgTransfer, createIbcAminoConverters } from "./aminomessages";

--- a/packages/stargate/src/modules/ibc/aminomessages.ts
+++ b/packages/stargate/src/modules/ibc/aminomessages.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { AminoMsg, Coin, omitDefault } from "@cosmjs/amino";
-import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
+import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx.js";
 
 import { AminoConverters } from "../../aminotypes";
 

--- a/packages/stargate/src/modules/ibc/ibctestdata.spec.ts
+++ b/packages/stargate/src/modules/ibc/ibctestdata.spec.ts
@@ -6,15 +6,15 @@ import {
   Order,
   PacketState,
   State as ChannelState,
-} from "cosmjs-types/ibc/core/channel/v1/channel";
-import { MerklePrefix } from "cosmjs-types/ibc/core/commitment/v1/commitment";
+} from "cosmjs-types/ibc/core/channel/v1/channel.js";
+import { MerklePrefix } from "cosmjs-types/ibc/core/commitment/v1/commitment.js";
 import {
   ConnectionEnd,
   Counterparty as ConnectionCounterparty,
   IdentifiedConnection,
   State as ConnectionState,
   Version,
-} from "cosmjs-types/ibc/core/connection/v1/connection";
+} from "cosmjs-types/ibc/core/connection/v1/connection.js";
 
 // From scripts/simapp42/genesis-ibc.json
 

--- a/packages/stargate/src/modules/ibc/messages.ts
+++ b/packages/stargate/src/modules/ibc/messages.ts
@@ -1,5 +1,5 @@
 import { EncodeObject, GeneratedType } from "@cosmjs/proto-signing";
-import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
+import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx.js";
 import {
   MsgAcknowledgement,
   MsgChannelCloseConfirm,
@@ -11,19 +11,19 @@ import {
   MsgRecvPacket,
   MsgTimeout,
   MsgTimeoutOnClose,
-} from "cosmjs-types/ibc/core/channel/v1/tx";
+} from "cosmjs-types/ibc/core/channel/v1/tx.js";
 import {
   MsgCreateClient,
   MsgSubmitMisbehaviour,
   MsgUpdateClient,
   MsgUpgradeClient,
-} from "cosmjs-types/ibc/core/client/v1/tx";
+} from "cosmjs-types/ibc/core/client/v1/tx.js";
 import {
   MsgConnectionOpenAck,
   MsgConnectionOpenConfirm,
   MsgConnectionOpenInit,
   MsgConnectionOpenTry,
-} from "cosmjs-types/ibc/core/connection/v1/tx";
+} from "cosmjs-types/ibc/core/connection/v1/tx.js";
 
 export const ibcTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/ibc.applications.transfer.v1.MsgTransfer", MsgTransfer],

--- a/packages/stargate/src/modules/ibc/queries.ts
+++ b/packages/stargate/src/modules/ibc/queries.ts
@@ -1,10 +1,10 @@
-import { Any } from "cosmjs-types/google/protobuf/any";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 import {
   QueryClientImpl as TransferQuery,
   QueryDenomTraceResponse,
   QueryDenomTracesResponse,
   QueryParamsResponse as QueryTransferParamsResponse,
-} from "cosmjs-types/ibc/applications/transfer/v1/query";
+} from "cosmjs-types/ibc/applications/transfer/v1/query.js";
 import {
   QueryChannelClientStateResponse,
   QueryChannelConsensusStateResponse,
@@ -21,8 +21,8 @@ import {
   QueryPacketReceiptResponse,
   QueryUnreceivedAcksResponse,
   QueryUnreceivedPacketsResponse,
-} from "cosmjs-types/ibc/core/channel/v1/query";
-import { Height } from "cosmjs-types/ibc/core/client/v1/client";
+} from "cosmjs-types/ibc/core/channel/v1/query.js";
+import { Height } from "cosmjs-types/ibc/core/client/v1/client.js";
 import {
   QueryClientImpl as ClientQuery,
   QueryClientParamsResponse,
@@ -31,7 +31,7 @@ import {
   QueryConsensusStateRequest,
   QueryConsensusStateResponse,
   QueryConsensusStatesResponse,
-} from "cosmjs-types/ibc/core/client/v1/query";
+} from "cosmjs-types/ibc/core/client/v1/query.js";
 import {
   QueryClientConnectionsResponse,
   QueryClientImpl as ConnectionQuery,
@@ -40,11 +40,11 @@ import {
   QueryConnectionConsensusStateResponse,
   QueryConnectionResponse,
   QueryConnectionsResponse,
-} from "cosmjs-types/ibc/core/connection/v1/query";
+} from "cosmjs-types/ibc/core/connection/v1/query.js";
 import {
   ClientState as TendermintClientState,
   ConsensusState as TendermintConsensusState,
-} from "cosmjs-types/ibc/lightclients/tendermint/v1/tendermint";
+} from "cosmjs-types/ibc/lightclients/tendermint/v1/tendermint.js";
 
 import { createPagination, createProtobufRpcClient, longify, QueryClient } from "../../queryclient";
 

--- a/packages/stargate/src/modules/mint/queries.ts
+++ b/packages/stargate/src/modules/mint/queries.ts
@@ -1,12 +1,12 @@
 import { Decimal } from "@cosmjs/math";
 import { assert } from "@cosmjs/utils";
-import { Params } from "cosmjs-types/cosmos/mint/v1beta1/mint";
-import { QueryClientImpl } from "cosmjs-types/cosmos/mint/v1beta1/query";
+import { Params } from "cosmjs-types/cosmos/mint/v1beta1/mint.js";
+import { QueryClientImpl } from "cosmjs-types/cosmos/mint/v1beta1/query.js";
 
 import { createProtobufRpcClient, decodeCosmosSdkDecFromProto, QueryClient } from "../../queryclient";
 
 /**
- * Like Params from "cosmjs-types/cosmos/mint/v1beta1/mint"
+ * Like Params from "cosmjs-types/cosmos/mint/v1beta1/mint.js"
  * but using decimal types.
  */
 export interface MintParams extends Pick<Params, "blocksPerYear" | "mintDenom"> {

--- a/packages/stargate/src/modules/slashing/queries.ts
+++ b/packages/stargate/src/modules/slashing/queries.ts
@@ -3,7 +3,7 @@ import {
   QueryParamsResponse,
   QuerySigningInfoResponse,
   QuerySigningInfosResponse,
-} from "cosmjs-types/cosmos/slashing/v1beta1/query";
+} from "cosmjs-types/cosmos/slashing/v1beta1/query.js";
 
 import { createPagination, createProtobufRpcClient, QueryClient } from "../../queryclient";
 

--- a/packages/stargate/src/modules/staking/aminomessages.spec.ts
+++ b/packages/stargate/src/modules/staking/aminomessages.spec.ts
@@ -1,6 +1,6 @@
 import { fromBase64 } from "@cosmjs/encoding";
 import { coin } from "@cosmjs/proto-signing";
-import { PubKey as CosmosCryptoSecp256k1Pubkey } from "cosmjs-types/cosmos/crypto/secp256k1/keys";
+import { PubKey as CosmosCryptoSecp256k1Pubkey } from "cosmjs-types/cosmos/crypto/secp256k1/keys.js";
 import {
   MsgBeginRedelegate,
   MsgCancelUnbondingDelegation,
@@ -8,7 +8,7 @@ import {
   MsgDelegate,
   MsgEditValidator,
   MsgUndelegate,
-} from "cosmjs-types/cosmos/staking/v1beta1/tx";
+} from "cosmjs-types/cosmos/staking/v1beta1/tx.js";
 
 import { AminoTypes } from "../../aminotypes";
 import {

--- a/packages/stargate/src/modules/staking/aminomessages.ts
+++ b/packages/stargate/src/modules/staking/aminomessages.ts
@@ -10,7 +10,7 @@ import {
   MsgDelegate,
   MsgEditValidator,
   MsgUndelegate,
-} from "cosmjs-types/cosmos/staking/v1beta1/tx";
+} from "cosmjs-types/cosmos/staking/v1beta1/tx.js";
 
 import { AminoConverter } from "../..";
 

--- a/packages/stargate/src/modules/staking/messages.ts
+++ b/packages/stargate/src/modules/staking/messages.ts
@@ -6,7 +6,7 @@ import {
   MsgDelegate,
   MsgEditValidator,
   MsgUndelegate,
-} from "cosmjs-types/cosmos/staking/v1beta1/tx";
+} from "cosmjs-types/cosmos/staking/v1beta1/tx.js";
 
 export const stakingTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/cosmos.staking.v1beta1.MsgBeginRedelegate", MsgBeginRedelegate],

--- a/packages/stargate/src/modules/staking/queries.spec.ts
+++ b/packages/stargate/src/modules/staking/queries.spec.ts
@@ -1,7 +1,7 @@
 import { coin, coins, DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import { CometClient, connectComet } from "@cosmjs/tendermint-rpc";
 import { sleep } from "@cosmjs/utils";
-import { MsgDelegate, MsgUndelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
+import { MsgDelegate, MsgUndelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx.js";
 
 import { QueryClient } from "../../queryclient";
 import { SigningStargateClient } from "../../signingstargateclient";

--- a/packages/stargate/src/modules/staking/queries.ts
+++ b/packages/stargate/src/modules/staking/queries.ts
@@ -14,8 +14,8 @@ import {
   QueryValidatorResponse,
   QueryValidatorsResponse,
   QueryValidatorUnbondingDelegationsResponse,
-} from "cosmjs-types/cosmos/staking/v1beta1/query";
-import { BondStatus } from "cosmjs-types/cosmos/staking/v1beta1/staking";
+} from "cosmjs-types/cosmos/staking/v1beta1/query.js";
+import { BondStatus } from "cosmjs-types/cosmos/staking/v1beta1/staking.js";
 
 import { createPagination, createProtobufRpcClient, QueryClient } from "../../queryclient";
 

--- a/packages/stargate/src/modules/tx/queries.spec.ts
+++ b/packages/stargate/src/modules/tx/queries.spec.ts
@@ -1,7 +1,7 @@
 import { coin, coins, DirectSecp256k1HdWallet, Registry } from "@cosmjs/proto-signing";
 import { CometClient, connectComet } from "@cosmjs/tendermint-rpc";
 import { assertDefined, sleep } from "@cosmjs/utils";
-import { MsgDelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
+import { MsgDelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx.js";
 
 import { QueryClient } from "../../queryclient";
 import { defaultRegistryTypes, SigningStargateClient } from "../../signingstargateclient";

--- a/packages/stargate/src/modules/tx/queries.ts
+++ b/packages/stargate/src/modules/tx/queries.ts
@@ -1,15 +1,15 @@
 import { Pubkey } from "@cosmjs/amino";
 import { encodePubkey } from "@cosmjs/proto-signing";
-import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
+import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing.js";
 import {
   GetTxRequest,
   GetTxResponse,
   ServiceClientImpl,
   SimulateRequest,
   SimulateResponse,
-} from "cosmjs-types/cosmos/tx/v1beta1/service";
-import { AuthInfo, Fee, Tx, TxBody } from "cosmjs-types/cosmos/tx/v1beta1/tx";
-import { Any } from "cosmjs-types/google/protobuf/any";
+} from "cosmjs-types/cosmos/tx/v1beta1/service.js";
+import { AuthInfo, Fee, Tx, TxBody } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 
 import { createProtobufRpcClient, QueryClient } from "../../queryclient";
 

--- a/packages/stargate/src/modules/vesting/aminomessages.spec.ts
+++ b/packages/stargate/src/modules/vesting/aminomessages.spec.ts
@@ -1,5 +1,5 @@
 import { coins } from "@cosmjs/amino";
-import { MsgCreateVestingAccount } from "cosmjs-types/cosmos/vesting/v1beta1/tx";
+import { MsgCreateVestingAccount } from "cosmjs-types/cosmos/vesting/v1beta1/tx.js";
 
 import { AminoTypes } from "../../aminotypes";
 import { AminoMsgCreateVestingAccount, createVestingAminoConverters } from "./aminomessages";

--- a/packages/stargate/src/modules/vesting/aminomessages.ts
+++ b/packages/stargate/src/modules/vesting/aminomessages.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { AminoMsg, Coin } from "@cosmjs/amino";
-import { MsgCreateVestingAccount } from "cosmjs-types/cosmos/vesting/v1beta1/tx";
+import { MsgCreateVestingAccount } from "cosmjs-types/cosmos/vesting/v1beta1/tx.js";
 
 import { AminoConverters } from "../../aminotypes";
 

--- a/packages/stargate/src/modules/vesting/messages.spec.ts
+++ b/packages/stargate/src/modules/vesting/messages.spec.ts
@@ -1,6 +1,6 @@
 import { coin, coins, Secp256k1HdWallet } from "@cosmjs/amino";
 import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
-import { MsgCreateVestingAccount } from "cosmjs-types/cosmos/vesting/v1beta1/tx";
+import { MsgCreateVestingAccount } from "cosmjs-types/cosmos/vesting/v1beta1/tx.js";
 
 import { SigningStargateClient } from "../../signingstargateclient";
 import { assertIsDeliverTxSuccess } from "../../stargateclient";

--- a/packages/stargate/src/modules/vesting/messages.ts
+++ b/packages/stargate/src/modules/vesting/messages.ts
@@ -1,5 +1,5 @@
 import { GeneratedType } from "@cosmjs/proto-signing";
-import { MsgCreateVestingAccount } from "cosmjs-types/cosmos/vesting/v1beta1/tx";
+import { MsgCreateVestingAccount } from "cosmjs-types/cosmos/vesting/v1beta1/tx.js";
 
 export const vestingTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/cosmos.vesting.v1beta1.MsgCreateVestingAccount", MsgCreateVestingAccount],

--- a/packages/stargate/src/multisignature.spec.ts
+++ b/packages/stargate/src/multisignature.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "@cosmjs/amino";
 import { coins } from "@cosmjs/proto-signing";
 import { assert } from "@cosmjs/utils";
-import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
+import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx.js";
 
 import { MsgSendEncodeObject } from "./modules";
 import { makeCompactBitArray, makeMultisignedTxBytes } from "./multisignature";

--- a/packages/stargate/src/multisignature.ts
+++ b/packages/stargate/src/multisignature.ts
@@ -1,9 +1,9 @@
 import { MultisigThresholdPubkey, pubkeyToAddress, StdFee } from "@cosmjs/amino";
 import { fromBech32 } from "@cosmjs/encoding";
 import { encodePubkey } from "@cosmjs/proto-signing";
-import { CompactBitArray, MultiSignature } from "cosmjs-types/cosmos/crypto/multisig/v1beta1/multisig";
-import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
-import { AuthInfo, SignerInfo, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { CompactBitArray, MultiSignature } from "cosmjs-types/cosmos/crypto/multisig/v1beta1/multisig.js";
+import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing.js";
+import { AuthInfo, SignerInfo, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
 
 export function makeCompactBitArray(bits: readonly boolean[]): CompactBitArray {
   const byteCount = Math.ceil(bits.length / 8);

--- a/packages/stargate/src/queryclient/queryclient.spec.ts
+++ b/packages/stargate/src/queryclient/queryclient.spec.ts
@@ -7,7 +7,7 @@ import {
   QueryAllBalancesResponse,
   QueryBalanceRequest,
   QueryBalanceResponse,
-} from "cosmjs-types/cosmos/bank/v1beta1/query";
+} from "cosmjs-types/cosmos/bank/v1beta1/query.js";
 
 import { SigningStargateClient } from "../signingstargateclient";
 import {

--- a/packages/stargate/src/queryclient/queryclient.ts
+++ b/packages/stargate/src/queryclient/queryclient.ts
@@ -1,6 +1,6 @@
 import { CometClient } from "@cosmjs/tendermint-rpc";
 import { assert, isNonNullObject } from "@cosmjs/utils";
-import { ProofOps } from "cosmjs-types/tendermint/crypto/proof";
+import { ProofOps } from "cosmjs-types/tendermint/crypto/proof.js";
 
 type QueryExtensionSetup<P> = (base: QueryClient) => P;
 

--- a/packages/stargate/src/queryclient/utils.ts
+++ b/packages/stargate/src/queryclient/utils.ts
@@ -1,6 +1,6 @@
 import { fromAscii, fromBech32 } from "@cosmjs/encoding";
 import { Decimal, Uint64 } from "@cosmjs/math";
-import { PageRequest } from "cosmjs-types/cosmos/base/query/v1beta1/pagination";
+import { PageRequest } from "cosmjs-types/cosmos/base/query/v1beta1/pagination.js";
 
 import { QueryClient } from "./queryclient";
 

--- a/packages/stargate/src/signingstargateclient.spec.ts
+++ b/packages/stargate/src/signingstargateclient.spec.ts
@@ -11,14 +11,14 @@ import {
 import { connectComet } from "@cosmjs/tendermint-rpc";
 import { assert, sleep } from "@cosmjs/utils";
 import { DeepPartial } from "cosmjs-types";
-import { BinaryWriter } from "cosmjs-types/binary";
-import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
-import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
-import { BasicAllowance } from "cosmjs-types/cosmos/feegrant/v1beta1/feegrant";
-import { MsgGrantAllowance } from "cosmjs-types/cosmos/feegrant/v1beta1/tx";
-import { MsgDelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
-import { AuthInfo, TxBody, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import { BinaryWriter } from "cosmjs-types/binary.js";
+import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx.js";
+import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin.js";
+import { BasicAllowance } from "cosmjs-types/cosmos/feegrant/v1beta1/feegrant.js";
+import { MsgGrantAllowance } from "cosmjs-types/cosmos/feegrant/v1beta1/tx.js";
+import { MsgDelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx.js";
+import { AuthInfo, TxBody, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
+import { Any } from "cosmjs-types/google/protobuf/any.js";
 
 import { AminoTypes } from "./aminotypes";
 import {

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -14,13 +14,13 @@ import {
 } from "@cosmjs/proto-signing";
 import { CometClient, connectComet, HttpEndpoint } from "@cosmjs/tendermint-rpc";
 import { assert, assertDefined } from "@cosmjs/utils";
-import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
-import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
-import { MsgDelegate, MsgUndelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
-import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
-import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
-import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
-import { Height } from "cosmjs-types/ibc/core/client/v1/client";
+import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin.js";
+import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx.js";
+import { MsgDelegate, MsgUndelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx.js";
+import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing.js";
+import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
+import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx.js";
+import { Height } from "cosmjs-types/ibc/core/client/v1/client.js";
 
 import { AminoConverters, AminoTypes } from "./aminotypes";
 import { calculateFee, GasPrice } from "./fee";

--- a/packages/stargate/src/stargateclient.searchtx.spec.ts
+++ b/packages/stargate/src/stargateclient.searchtx.spec.ts
@@ -10,9 +10,9 @@ import {
   TxBodyEncodeObject,
 } from "@cosmjs/proto-signing";
 import { assert, sleep } from "@cosmjs/utils";
-import { MsgSendResponse } from "cosmjs-types/cosmos/bank/v1beta1/tx";
-import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
-import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { MsgSendResponse } from "cosmjs-types/cosmos/bank/v1beta1/tx.js";
+import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin.js";
+import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
 
 import { isMsgSendEncodeObject } from "./modules";
 import { DeliverTxResponse, isDeliverTxFailure, isDeliverTxSuccess, StargateClient } from "./stargateclient";

--- a/packages/stargate/src/stargateclient.spec.ts
+++ b/packages/stargate/src/stargateclient.spec.ts
@@ -9,7 +9,7 @@ import {
   TxBodyEncodeObject,
 } from "@cosmjs/proto-signing";
 import { assert, sleep } from "@cosmjs/utils";
-import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
 import { ReadonlyDate } from "readonly-date";
 
 import {

--- a/packages/stargate/src/stargateclient.ts
+++ b/packages/stargate/src/stargateclient.ts
@@ -3,10 +3,10 @@ import { toHex } from "@cosmjs/encoding";
 import { Uint53 } from "@cosmjs/math";
 import { CometClient, connectComet, HttpEndpoint, toRfc3339WithNanoseconds } from "@cosmjs/tendermint-rpc";
 import { assert, sleep } from "@cosmjs/utils";
-import { MsgData, TxMsgData } from "cosmjs-types/cosmos/base/abci/v1beta1/abci";
-import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
-import { QueryDelegatorDelegationsResponse } from "cosmjs-types/cosmos/staking/v1beta1/query";
-import { DelegationResponse } from "cosmjs-types/cosmos/staking/v1beta1/staking";
+import { MsgData, TxMsgData } from "cosmjs-types/cosmos/base/abci/v1beta1/abci.js";
+import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin.js";
+import { QueryDelegatorDelegationsResponse } from "cosmjs-types/cosmos/staking/v1beta1/query.js";
+import { DelegationResponse } from "cosmjs-types/cosmos/staking/v1beta1/staking.js";
 
 import { Account, accountFromAny, AccountParser } from "./accounts";
 import { Event, fromTendermintEvent } from "./events";

--- a/packages/stargate/src/testutils.spec.ts
+++ b/packages/stargate/src/testutils.spec.ts
@@ -9,8 +9,8 @@ import {
   makeAuthInfoBytes,
 } from "@cosmjs/proto-signing";
 import { assertDefinedAndNotNull } from "@cosmjs/utils";
-import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
-import { AuthInfo, SignDoc, TxBody } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing.js";
+import { AuthInfo, SignDoc, TxBody } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
 
 import { calculateFee, GasPrice } from "./fee";
 import { SigningStargateClientOptions } from "./signingstargateclient";


### PR DESCRIPTION
```sh
sed -i -E 's/(from "cosmjs-types.+)";$/\1.js";/' `grep cosmjs-types/ -rlI packages/`
```

Omitting a file extension only works when transpiled to CJS.

Prerequisite for #1004