### PR TITLE
chore: remove redundant word in .github/workflows/faucet.yml

### DIFF
--- a/.github/workflows/faucet.yml
+++ b/.github/workflows/faucet.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           lfs: true
 
-      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:


### PR DESCRIPTION
 remove redundant word in .github/workflows/faucet.yml