### PR TITLE
fix(comments): correct typos in test descriptions and comments

### DIFF
--- a/packages/stargate/src/modules/bank/queries.spec.ts
+++ b/packages/stargate/src/modules/bank/queries.spec.ts
@@ -143,7 +143,7 @@ describe("BankExtension", () => {
   });
 
   describe("denomMetadata", () => {
-    it("works for existent denom", async () => {
+    it("works for existing denom", async () => {
       pendingWithoutSimapp();
       const [client, cometClient] = await makeClientWithBank(simapp.tendermintUrlHttp);
 

--- a/packages/stream/src/concat.spec.ts
+++ b/packages/stream/src/concat.spec.ts
@@ -152,7 +152,7 @@ describe("concat", () => {
 
   it("unsubscribes and re-subscribes from source streams", (done) => {
     // For browsers and CI, clocks and runtimes are very unreliable.
-    // Especialls Mac+Firefox on Travis is makes big trouble. Thus we need huge intervals.
+    // Especially Mac+Firefox on Travis makes big trouble. Thus we need huge intervals.
     const intervalDuration = 1000;
     const producerActiveLog = new Array<boolean>();
 


### PR DESCRIPTION
- Changed "existent" to "existing" in BankExtension denomMetadata test description for improved clarity.
- Corrected "Especialls" to "Especially" in concat.spec.ts comment about browser/CI timing issues.

