### PR TITLE
amino: mark encryption functions as `@deprecated`

### DIFF
--- a/packages/amino/src/secp256k1hdwallet.ts
+++ b/packages/amino/src/secp256k1hdwallet.ts
@@ -171,6 +171,8 @@ export class Secp256k1HdWallet implements OfflineAminoSigner {
    *
    * @param password The user provided password used to generate an encryption key via a KDF.
    *                 This is not normalized internally (see "Unicode normalization" to learn more).
+   *
+   * @deprecated Encryption support may be removed from CosmJS in a future version. If you actually use this, comment at https://github.com/cosmos/cosmjs/issues/1796
    */
   public static async deserialize(serialization: string, password: string): Promise<Secp256k1HdWallet> {
     const root = JSON.parse(serialization);
@@ -191,6 +193,8 @@ export class Secp256k1HdWallet implements OfflineAminoSigner {
    *
    * The caller is responsible for ensuring the key was derived with the given KDF configuration. This can be
    * done using `extractKdfConfiguration(serialization)` and `executeKdf(password, kdfConfiguration)` from this package.
+   *
+   * @deprecated Encryption support may be removed from CosmJS in a future version. If you actually use this, comment at https://github.com/cosmos/cosmjs/issues/1796
    */
   public static async deserializeWithEncryptionKey(
     serialization: string,
@@ -290,6 +294,8 @@ export class Secp256k1HdWallet implements OfflineAminoSigner {
    *
    * @param password The user provided password used to generate an encryption key via a KDF.
    *                 This is not normalized internally (see "Unicode normalization" to learn more).
+   *
+   * @deprecated Encryption support may be removed from CosmJS in a future version. If you actually use this, comment at https://github.com/cosmos/cosmjs/issues/1796
    */
   public async serialize(password: string): Promise<string> {
     const kdfConfiguration = basicPasswordHashingOptions;
@@ -305,6 +311,8 @@ export class Secp256k1HdWallet implements OfflineAminoSigner {
    *
    * The caller is responsible for ensuring the key was derived with the given KDF options. If this
    * is not the case, the wallet cannot be restored with the original password.
+   *
+   * @deprecated Encryption support may be removed from CosmJS in a future version. If you actually use this, comment at https://github.com/cosmos/cosmjs/issues/1796
    */
   public async serializeWithEncryptionKey(
     encryptionKey: Uint8Array,

--- a/packages/amino/src/wallet.ts
+++ b/packages/amino/src/wallet.ts
@@ -23,6 +23,9 @@ export interface KdfConfiguration {
   readonly params: Record<string, unknown>;
 }
 
+/**
+ * @deprecated Encryption support may be removed from CosmJS in a future version. If you actually use this, comment at https://github.com/cosmos/cosmjs/issues/1796
+ */
 export async function executeKdf(password: string, configuration: KdfConfiguration): Promise<Uint8Array> {
   switch (configuration.algorithm) {
     case "argon2id": {
@@ -52,6 +55,9 @@ export const supportedAlgorithms = {
   xchacha20poly1305Ietf: "xchacha20poly1305-ietf",
 };
 
+/**
+ * @deprecated Encryption support may be removed from CosmJS in a future version. If you actually use this, comment at https://github.com/cosmos/cosmjs/issues/1796
+ */
 export async function encrypt(
   plaintext: Uint8Array,
   encryptionKey: Uint8Array,
@@ -71,6 +77,9 @@ export async function encrypt(
   }
 }
 
+/**
+ * @deprecated Encryption support may be removed from CosmJS in a future version. If you actually use this, comment at https://github.com/cosmos/cosmjs/issues/1796
+ */
 export async function decrypt(
   ciphertext: Uint8Array,
   encryptionKey: Uint8Array,

--- a/packages/proto-signing/src/directsecp256k1hdwallet.ts
+++ b/packages/proto-signing/src/directsecp256k1hdwallet.ts
@@ -170,6 +170,8 @@ export class DirectSecp256k1HdWallet implements OfflineDirectSigner {
    *
    * @param password The user provided password used to generate an encryption key via a KDF.
    *                 This is not normalized internally (see "Unicode normalization" to learn more).
+   *
+   * @deprecated Encryption support may be removed from CosmJS in a future version. If you actually use this, comment at https://github.com/cosmos/cosmjs/issues/1796
    */
   public static async deserialize(serialization: string, password: string): Promise<DirectSecp256k1HdWallet> {
     const root = JSON.parse(serialization);
@@ -189,6 +191,8 @@ export class DirectSecp256k1HdWallet implements OfflineDirectSigner {
    *
    * The caller is responsible for ensuring the key was derived with the given KDF configuration. This can be
    * done using `extractKdfConfiguration(serialization)` and `executeKdf(password, kdfConfiguration)` from this package.
+   *
+   * @deprecated Encryption support may be removed from CosmJS in a future version. If you actually use this, comment at https://github.com/cosmos/cosmjs/issues/1796
    */
   public static async deserializeWithEncryptionKey(
     serialization: string,
@@ -290,6 +294,8 @@ export class DirectSecp256k1HdWallet implements OfflineDirectSigner {
    *
    * @param password The user provided password used to generate an encryption key via a KDF.
    *                 This is not normalized internally (see "Unicode normalization" to learn more).
+   *
+   * @deprecated Encryption support may be removed from CosmJS in a future version. If you actually use this, comment at https://github.com/cosmos/cosmjs/issues/1796
    */
   public async serialize(password: string): Promise<string> {
     const kdfConfiguration = basicPasswordHashingOptions;
@@ -305,6 +311,8 @@ export class DirectSecp256k1HdWallet implements OfflineDirectSigner {
    *
    * The caller is responsible for ensuring the key was derived with the given KDF options. If this
    * is not the case, the wallet cannot be restored with the original password.
+   *
+   * @deprecated Encryption support may be removed from CosmJS in a future version. If you actually use this, comment at https://github.com/cosmos/cosmjs/issues/1796
    */
   public async serializeWithEncryptionKey(
     encryptionKey: Uint8Array,


### PR DESCRIPTION
Before actually doing #1479, make sure actual users get linked to the discussion in #1796.

This should probably be in a 0.35.1 release. Or even backported further.