### PR TITLE
test: fix typos in RFC3339 and webserver test descriptions

### DIFF
--- a/packages/encoding/src/rfc3339.spec.ts
+++ b/packages/encoding/src/rfc3339.spec.ts
@@ -85,7 +85,7 @@ describe("RFC3339", () => {
     expect(fromRfc3339("2002-10-02T11:12:13.1Z")).toEqual(new Date(Date.UTC(2002, 9, 2, 11, 12, 13, 100)));
     expect(fromRfc3339("2002-10-02T11:12:13.9Z")).toEqual(new Date(Date.UTC(2002, 9, 2, 11, 12, 13, 900)));
 
-    // 2 digit
+    // 2 digits
     expect(fromRfc3339("2002-10-02T11:12:13.00Z")).toEqual(new Date(Date.UTC(2002, 9, 2, 11, 12, 13, 0)));
     expect(fromRfc3339("2002-10-02T11:12:13.12Z")).toEqual(new Date(Date.UTC(2002, 9, 2, 11, 12, 13, 120)));
     expect(fromRfc3339("2002-10-02T11:12:13.99Z")).toEqual(new Date(Date.UTC(2002, 9, 2, 11, 12, 13, 990)));

--- a/packages/faucet/src/api/webserver.spec.ts
+++ b/packages/faucet/src/api/webserver.spec.ts
@@ -7,7 +7,7 @@ import { ChainConstants, Webserver } from "./webserver";
 
 function pendingWithoutSimapp(): void {
   if (!process.env.SIMAPP47_ENABLED && !process.env.SIMAPP50_ENABLED) {
-    pending("Set SIMAPP{47,50}_ENABLED to enabled Stargate node-based tests");
+    pending("Set SIMAPP{47,50}_ENABLED to enable Stargate node-based tests");
     return;
   }
 }


### PR DESCRIPTION
- Corrected comment typo: "2 digit" → "2 digits" in RFC3339 spec test.
- Updated pending message for clarity in webserver spec test.
