### PR TITLE
fix: remove duplicate mnemonic assertion in wallet test

### DIFF
--- a/packages/proto-signing/src/directsecp256k1hdwallet.spec.ts
+++ b/packages/proto-signing/src/directsecp256k1hdwallet.spec.ts
@@ -197,7 +197,6 @@ describe("DirectSecp256k1HdWallet", () => {
         const accounts = await deserialized.getAccounts();
 
         expect(deserialized.mnemonic).toEqual(mnemonic);
-        expect(deserialized.mnemonic).toEqual(mnemonic);
         // These values are taken from the generate_addresses.js script in the scripts/wasmd directory
         expect(accounts).toEqual([
           {


### PR DESCRIPTION
 Remove duplicate expect statement for mnemonic validation in DirectSecp256k1HdWallet test suite