### PR TITLE
Upgrade GitHub Action to setup-go@v6

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 20
           cache: 'yarn'
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "oldstable"
 


### PR DESCRIPTION
The v5 version is outdated — v6 provides improved caching, setup performance, and compatibility with the latest Go releases.
Release notes: https://github.com/actions/setup-go/releases/tag/v6.0.0