### PR TITLE
Remove comments that belong to deleted onError

### DIFF
--- a/packages/tendermint-rpc/src/comet38/comet38client.spec.ts
+++ b/packages/tendermint-rpc/src/comet38/comet38client.spec.ts
@@ -873,7 +873,6 @@ function websocketTestSuite(rpcFactory: () => RpcClient, expected: ExpectedValue
   });
 
   describe("With WebsocketClient", () => {
-    // don't print out WebSocket errors if marked pending
     const factory = (): WebsocketClient => new WebsocketClient("ws://" + url, console.error);
     defaultTestSuite(factory, expected);
     websocketTestSuite(factory, expected);

--- a/packages/tendermint-rpc/src/tendermint34/tendermint34client.spec.ts
+++ b/packages/tendermint-rpc/src/tendermint34/tendermint34client.spec.ts
@@ -868,7 +868,6 @@ function websocketTestSuite(rpcFactory: () => RpcClient, expected: ExpectedValue
   });
 
   describe("With WebsocketClient", () => {
-    // don't print out WebSocket errors if marked pending
     const factory = (): WebsocketClient => new WebsocketClient("ws://" + url, console.error);
     defaultTestSuite(factory, expected);
     websocketTestSuite(factory, expected);

--- a/packages/tendermint-rpc/src/tendermint37/tendermint37client.spec.ts
+++ b/packages/tendermint-rpc/src/tendermint37/tendermint37client.spec.ts
@@ -870,7 +870,6 @@ function websocketTestSuite(rpcFactory: () => RpcClient, expected: ExpectedValue
   });
 
   describe("With WebsocketClient", () => {
-    // don't print out WebSocket errors if marked pending
     const factory = (): WebsocketClient => new WebsocketClient("ws://" + url, console.error);
     defaultTestSuite(factory, expected);
     websocketTestSuite(factory, expected);


### PR DESCRIPTION
Follow-up of #1835. The comments belong to the variable `onError` that got deleted