### PR TITLE
cosmwasm-stargate: xit() two disabled tests

### DIFF
--- a/packages/cosmwasm-stargate/src/signingcosmwasmclient.spec.ts
+++ b/packages/cosmwasm-stargate/src/signingcosmwasmclient.spec.ts
@@ -147,9 +147,8 @@ describe("SigningCosmWasmClient", () => {
       client.disconnect();
     });
 
-    it("works with Amino JSON signer (instantiatePermission set to one address)", async () => {
-      pending("Known issue: https://github.com/CosmWasm/wasmd/issues/1863");
-      pendingWithoutWasmd();
+    // Test disabled. Known issue: https://github.com/CosmWasm/wasmd/issues/1863
+    xit("works with Amino JSON signer (instantiatePermission set to one address)", async () => {
       const wallet = await Secp256k1HdWallet.fromMnemonic(alice.mnemonic, { prefix: wasmd.prefix });
       const client = await SigningCosmWasmClient.connectWithSigner(
         wasmd.endpoint,
@@ -175,9 +174,8 @@ describe("SigningCosmWasmClient", () => {
       client.disconnect();
     });
 
-    it("works with Amino JSON signer (instantiatePermission set to everybody)", async () => {
-      pending("Known issue: https://github.com/CosmWasm/wasmd/issues/1863");
-      pendingWithoutWasmd();
+    // Test disabled. Known issue: https://github.com/CosmWasm/wasmd/issues/1863
+    xit("works with Amino JSON signer (instantiatePermission set to everybody)", async () => {
       const wallet = await Secp256k1HdWallet.fromMnemonic(alice.mnemonic, { prefix: wasmd.prefix });
       const client = await SigningCosmWasmClient.connectWithSigner(
         wasmd.endpoint,


### PR DESCRIPTION
Disabled in #1579 due to https://github.com/CosmWasm/wasmd/issues/1863

https://github.com/cosmos/cosmjs/pull/1579/commits/e6361e9e63dd791e13286be517ef02e0d4272a33