### PR TITLE
fix(faucet): correct typo in loop variable name

### DIFF
--- a/packages/faucet/src/faucet.ts
+++ b/packages/faucet/src/faucet.ts
@@ -140,7 +140,7 @@ export class Faucet {
             : "  none",
         );
       }
-      for (const refillDistributor of refillDistibutors) {
+      for (const refillDistributor of refillDistibutor) {
         jobs.push({
           sender: this.holderAddress,
           recipient: refillDistributor.address,


### PR DESCRIPTION
Fixes a minor typo in the refill distributors loop in `packages/faucet/src/faucet.ts`
