### PR TITLE
fix: correct typo in comment

### DIFF
--- a/packages/amino/src/secp256k1hdwallet.ts
+++ b/packages/amino/src/secp256k1hdwallet.ts
@@ -203,7 +203,7 @@ export class Secp256k1HdWallet implements OfflineAminoSigner {
     const root = JSON.parse(serialization);
     if (!isNonNullObject(root)) throw new Error("Root document is not an object.");
     // This cast is safe because `root` comes from a valid JSON document and `root` is a non-null object.
-    // I.e. it can only be a JSON object, not an aribitrary JS object.
+    // I.e. it can only be a JSON object, not an arbitrary JS object.
     const untypedRoot: Record<string, any> = root;
     switch (untypedRoot.type) {
       case serializationTypeV1: {


### PR DESCRIPTION

## Description

Fixes a typo in the comment on line 206 of `secp256k1hdwallet.ts` where "aribitrary" should be "arbitrary".
