### PR TITLE
stargate, faucet: add missing .name field to Error subclasses

### DIFF
--- a/packages/faucet/src/api/httperror.ts
+++ b/packages/faucet/src/api/httperror.ts
@@ -4,6 +4,7 @@ export class HttpError extends Error {
 
   public constructor(status: number, text: string, expose = true) {
     super(text);
+    this.name = "HttpError";
     this.status = status;
     this.expose = expose;
   }

--- a/packages/stargate/src/stargateclient.ts
+++ b/packages/stargate/src/stargateclient.ts
@@ -28,6 +28,7 @@ export class TimeoutError extends Error {
 
   public constructor(message: string, txId: string) {
     super(message);
+    this.name = "TimeoutError";
     this.txId = txId;
   }
 }
@@ -179,6 +180,7 @@ export class BroadcastTxError extends Error {
 
   public constructor(code: number, codespace: string, log: string | undefined) {
     super(`Broadcasting transaction failed with code ${code} (codespace: ${codespace}). Log: ${log}`);
+    this.name = "BroadcastTxError";
     this.code = code;
     this.codespace = codespace;
     this.log = log;


### PR DESCRIPTION
They still had the default name `"Error"`.