### PR TITLE
fix typo in websocketclient.spec.ts variable name

### DIFF
--- a/packages/tendermint-rpc/src/rpcclients/websocketclient.spec.ts
+++ b/packages/tendermint-rpc/src/rpcclients/websocketclient.spec.ts
@@ -135,8 +135,8 @@ import { WebsocketClient } from "./websocketclient";
 
     client
       .execute(createJsonRpcRequest("status"))
-      .then((startusResponse) => {
-        expect(startusResponse).toBeTruthy();
+      .then((startupsResponse) => {
+        expect(startupsResponse).toBeTruthy();
       })
       .catch(done.fail);
 


### PR DESCRIPTION
Correct a variable name typo in websocket client test (`startusResponse` → `startupsResponse`).
