### PR TITLE
chore(ci): upgrade setup-node action to v6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
           lfs: true
 
       - name: Use Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'yarn'


### PR DESCRIPTION
move the workflow to actions/setup-node@v6 so the lint job runs on the current Node 24 toolchain;