### PR TITLE
Bring back main/types fields for bundlephobia support (0.37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Bring back main/types fields for bundlephobia support ([#1940])
+
+[#1940]: https://github.com/cosmos/cosmjs/pull/1940
+
 ## [0.37.0] - 2025-10-29
 
 ### Added

--- a/packages/amino/package.json
+++ b/packages/amino/package.json
@@ -6,6 +6,8 @@
     "Simon Warta <webmaster128@users.noreply.github.com>"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/cosmwasm-stargate/package.json
+++ b/packages/cosmwasm-stargate/package.json
@@ -6,6 +6,8 @@
     "Will Clark <willclarktech@users.noreply.github.com>"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -7,6 +7,8 @@
     "Simon Warta"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/encoding/package.json
+++ b/packages/encoding/package.json
@@ -6,6 +6,8 @@
     "IOV SAS <admin@iov.one>"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/faucet-client/package.json
+++ b/packages/faucet-client/package.json
@@ -6,6 +6,8 @@
     "Will Clark <willclarktech@users.noreply.github.com>"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/json-rpc/package.json
+++ b/packages/json-rpc/package.json
@@ -8,6 +8,8 @@
     "Will Clark <willclarktech@users.noreply.github.com>"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/ledger-amino/package.json
+++ b/packages/ledger-amino/package.json
@@ -6,6 +6,8 @@
     "Will Clark <willclarktech@users.noreply.github.com>"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -6,6 +6,8 @@
     "IOV SAS <admin@iov.one>"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/proto-signing/package.json
+++ b/packages/proto-signing/package.json
@@ -7,6 +7,8 @@
     "Simon Warta <webmaster128@users.noreply.github.com>"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/socket/package.json
+++ b/packages/socket/package.json
@@ -8,6 +8,8 @@
     "Will Clark <willclarktech@users.noreply.github.com>"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/stargate/package.json
+++ b/packages/stargate/package.json
@@ -6,6 +6,8 @@
     "Simon Warta <webmaster128@users.noreply.github.com>"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -8,6 +8,8 @@
     "Will Clark <willclarktech@users.noreply.github.com>"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/tendermint-rpc/package.json
+++ b/packages/tendermint-rpc/package.json
@@ -8,6 +8,8 @@
     "Will Clark <willclarktech@users.noreply.github.com>"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -6,6 +6,8 @@
     "IOV SAS <admin@iov.one>"
   ],
   "license": "Apache-2.0",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"


### PR DESCRIPTION
Starting with 0.37.0 we get the error

> EntryPointError
> 
> We could not guess a valid entry point for this package. Perhaps the author hasn't specified one in its package.json ?

from bundlephobia (e.g. https://bundlephobia.com/package/@cosmjs/cosmwasm-stargate@0.37.0).

You can consider this a bundlephobia issue but it is annoying for us and there is no harm in having main/types.