### PR TITLE
chore: fix inaccurate return value documentation in decodeUvarint function comment

### DIFF
--- a/packages/amino/src/encoding.ts
+++ b/packages/amino/src/encoding.ts
@@ -122,7 +122,7 @@ export function decodeBech32Pubkey(bechEncoded: string): Pubkey {
 /**
  * Uvarint decoder for Amino.
  * @see https://github.com/tendermint/go-amino/blob/8e779b71f40d175/decoder.go#L64-76
- * @returns varint as number, and bytes count occupied by varint
+ * @returns a tuple [varint as number, bytes count occupied by varint]
  */
 function decodeUvarint(reader: number[]): [number, number] {
   if (reader.length < 1) {


### PR DESCRIPTION


Updated the JSDoc comment for the `decodeUvarint` function to accurately describe its return value as a tuple varint as number, bytes count occupied by `varint` instead of the previous imprecise description.