### PR TITLE
test: add LegacyAminoPubKey decode coverage for multisig pubkeys

### DIFF
--- a/packages/proto-signing/src/pubkey.spec.ts
+++ b/packages/proto-signing/src/pubkey.spec.ts
@@ -1,4 +1,6 @@
 import { fromBase64 } from "@cosmjs/encoding";
+import { LegacyAminoPubKey } from "cosmjs-types/cosmos/crypto/multisig/keys";
+import { PubKey as CosmosCryptoSecp256k1Pubkey } from "cosmjs-types/cosmos/crypto/secp256k1/keys";
 import { Any } from "cosmjs-types/google/protobuf/any";
 
 import { decodePubkey, encodePubkey } from "./pubkey";
@@ -61,6 +63,42 @@ describe("pubkey", () => {
       expect(decodePubkey(pubkey)).toEqual({
         type: "tendermint/PubKeyEd25519",
         value: ed25519PubkeyBase64,
+      });
+    });
+
+    it("works for multisig (LegacyAminoPubKey)", () => {
+      const pubkey1Proto = CosmosCryptoSecp256k1Pubkey.fromPartial({
+        key: defaultPubkeyBytes,
+      });
+      const pubkey2Proto = CosmosCryptoSecp256k1Pubkey.fromPartial({
+        key: ed25519PubkeyBytes,
+      });
+      const multisigProto = LegacyAminoPubKey.fromPartial({
+        threshold: 2,
+        publicKeys: [
+          Any.fromPartial({
+            typeUrl: "/cosmos.crypto.secp256k1.PubKey",
+            value: Uint8Array.from(CosmosCryptoSecp256k1Pubkey.encode(pubkey1Proto).finish()),
+          }),
+          Any.fromPartial({
+            typeUrl: "/cosmos.crypto.secp256k1.PubKey",
+            value: Uint8Array.from(CosmosCryptoSecp256k1Pubkey.encode(pubkey2Proto).finish()),
+          }),
+        ],
+      });
+      const pubkey = Any.fromPartial({
+        typeUrl: "/cosmos.crypto.multisig.LegacyAminoPubKey",
+        value: Uint8Array.from(LegacyAminoPubKey.encode(multisigProto).finish()),
+      });
+      expect(decodePubkey(pubkey)).toEqual({
+        type: "tendermint/PubKeyMultisigThreshold",
+        value: {
+          threshold: "2",
+          pubkeys: [
+            { type: "tendermint/PubKeySecp256k1", value: defaultPubkeyBase64 },
+            { type: "tendermint/PubKeySecp256k1", value: ed25519PubkeyBase64 },
+          ],
+        },
       });
     });
 


### PR DESCRIPTION
## Summary

- Adds test coverage for the `decodePubkey` multisig branch (LegacyAminoPubKey) which was previously untested
- Creates a 2-of-2 multisig with two secp256k1 child keys, encodes as protobuf Any, verifies decodePubkey returns correct Amino JSON
- Validates threshold conversion (number to string) and recursive child pubkey decoding via anyToSinglePubkey

## Context

The existing test suite covered secp256k1 and ed25519 single pubkeys for both encodePubkey and decodePubkey, but the multisig code path at pubkey.ts:109-118 had zero test coverage. This matters because the multisig decode involves recursive decoding of child pubkeys and threshold type conversion.

## Test plan

- [x] Test creates valid LegacyAminoPubKey protobuf with threshold=2 and 2 child secp256k1 keys
- [x] Test verifies decoded output matches expected Amino JSON structure
- [ ] Run yarn test in packages/proto-signing to confirm

Relates to #1344

🤖 Generated with [Claude Code](https://claude.com/claude-code)