### PR TITLE
fix(ci): Pin evmd build to v0.5.1 instead of cosmos/evm@main

### DIFF
--- a/scripts/evmd/Dockerfile
+++ b/scripts/evmd/Dockerfile
@@ -1,4 +1,8 @@
-FROM golang:alpine AS builder
+# Pinned to 1.24 because cosmos/evm v0.5.1 transitively depends on
+# bytedance/sonic v1.14.2, which fails to compile on Go 1.25+ ("undefined:
+# GoMapIterator"). cosmos/evm's go.mod declares `go 1.23.8`, so 1.24 is
+# safely within range.
+FROM golang:1.24-alpine AS builder
 
 # Install dependencies
 RUN apk add --no-cache git make gcc musl-dev linux-headers ca-certificates

--- a/scripts/evmd/build.sh
+++ b/scripts/evmd/build.sh
@@ -7,8 +7,10 @@ SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR"/env
 
-# Allow specifying a specific version/branch/tag
-EVMD_VERSION="${EVMD_VERSION:-main}"
+# Allow specifying a specific version/branch/tag. Pinned to match VERSION in
+# ./env and ARG EVMD_VERSION in ./Dockerfile; building from a moving "main"
+# breaks CI when upstream changes the expected config.toml schema.
+EVMD_VERSION="${EVMD_VERSION:-v0.5.1}"
 
 echo "Building evmd Docker image from cosmos/evm@$EVMD_VERSION..."
 docker build \


### PR DESCRIPTION
## Summary

`scripts/evmd/build.sh` defaulted `EVMD_VERSION` to `main`, so every CI run rebuilt the evmd Docker image from whatever HEAD of `cosmos/evm` happened to be at the time. Upstream changed its mempool / `config.toml` schema and the templated config no longer satisfies it:

```
6:04PM ERR configs mismatch
  error="EVM mempool enabled, but comet-bft has invalid config.toml:
  mempool.type (want 'app', got 'flood'): error in app.toml"
  module=server
Error: EVM mempool enabled, but comet-bft has invalid config.toml:
  mempool.type (want 'app', got 'flood'): error in app.toml
```

The container exited immediately, the `Initialize evmd` step timed out at 60s, and the `test`, `test-backends`, `test-chrome`, and `test-with-coverage` jobs all failed with exit code 124. This had been breaking every PR (e.g. #1956).

Pinning to `v0.5.1` then surfaced a second, latent issue: the unpinned `golang:alpine` base image had rolled to Go 1.25+, and Go 1.25 removed the runtime `GoMapIterator` symbol that `bytedance/sonic v1.14.2` (a transitive dep of `cosmos/evm v0.5.1`) references — see [bytedance/sonic#895](https://github.com/bytedance/sonic/issues/895):

```
/go/pkg/mod/github.com/bytedance/sonic@v1.14.2/internal/rt/stubs.go:33:22:
  undefined: GoMapIterator
make: *** [Makefile:93: build] Error 1
```

## Changes

1. **`scripts/evmd/build.sh`** — default `EVMD_VERSION` to `v0.5.1` so the source we build matches `VERSION` in `scripts/evmd/env` (the `cosmjs/evmd:v0.5.1` image tag), `ARG EVMD_VERSION=v0.5.1` in `scripts/evmd/Dockerfile`, and the templated `app.toml` / `config.toml`. The override env var is preserved for local experimentation.
2. **`scripts/evmd/Dockerfile`** — pin the builder to `golang:1.24-alpine`. `cosmos/evm v0.5.1`'s `go.mod` declares `go 1.23.8`, so 1.24 satisfies the toolchain requirement while staying below the Go 1.25 break.

## Test plan

- [x] `bash -n scripts/evmd/build.sh` — clean
- [x] `EVMD_VERSION=…` override still works (default is `:-v0.5.1`)
- [ ] CI builds `cosmjs/evmd:v0.5.1` from `cosmos/evm@v0.5.1` on `golang:1.24-alpine` and `Initialize evmd` returns within 60s on this PR