### PR TITLE
Add npm metadata for proto-signing and stargate

### DIFF
--- a/packages/proto-signing/package.json
+++ b/packages/proto-signing/package.json
@@ -25,6 +25,10 @@
     "type": "git",
     "url": "https://github.com/cosmos/cosmjs/tree/main/packages/proto-signing"
   },
+  "homepage": "https://github.com/cosmos/cosmjs/tree/main/packages/proto-signing#readme",
+  "bugs": {
+    "url": "https://github.com/cosmos/cosmjs/issues"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/stargate/package.json
+++ b/packages/stargate/package.json
@@ -24,6 +24,10 @@
     "type": "git",
     "url": "https://github.com/cosmos/cosmjs/tree/main/packages/stargate"
   },
+  "homepage": "https://github.com/cosmos/cosmjs/tree/main/packages/stargate#readme",
+  "bugs": {
+    "url": "https://github.com/cosmos/cosmjs/issues"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Adds `homepage` and `bugs` metadata to the `@cosmjs/proto-signing` and `@cosmjs/stargate` package manifests so the fields are included in published npm metadata.

Verification:
- `node -e "for (const f of ['packages/proto-signing/package.json','packages/stargate/package.json']) { const p=require('./'+f); if (!p.homepage || !p.bugs?.url) throw new Error(f); console.log(f, p.homepage, p.bugs.url); }"`
- `git diff --check`