### PR TITLE
Validate RFC3339 date/time component ranges

### DIFF
--- a/packages/encoding/src/rfc3339.spec.ts
+++ b/packages/encoding/src/rfc3339.spec.ts
@@ -158,6 +158,10 @@ describe("RFC3339", () => {
     expect(fromRfc3339("2002-10-02 11:12:13Z")).toEqual(new Date(Date.UTC(2002, 9, 2, 11, 12, 13)));
   });
 
+  it("parses leap days", () => {
+    expect(fromRfc3339("2000-02-29T11:12:13Z")).toEqual(new Date(Date.UTC(2000, 1, 29, 11, 12, 13)));
+  });
+
   it("throws for invalid format", () => {
     // extra whitespace
     expect(() => fromRfc3339(" 2002-10-02T11:12:13Z")).toThrow();
@@ -190,6 +194,17 @@ describe("RFC3339", () => {
     // wrong fractional seconds
     expect(() => fromRfc3339("2018-07-30T19:21:12345Z")).toThrow();
     expect(() => fromRfc3339("2018-07-30T19:21:12.Z")).toThrow();
+  });
+
+  it("throws for out-of-range date and time components", () => {
+    expect(() => fromRfc3339("2002-00-02T11:12:13Z")).toThrow();
+    expect(() => fromRfc3339("2002-13-02T11:12:13Z")).toThrow();
+    expect(() => fromRfc3339("2002-02-30T11:12:13Z")).toThrow();
+    expect(() => fromRfc3339("2001-02-29T11:12:13Z")).toThrow();
+    expect(() => fromRfc3339("2002-10-02T24:12:13Z")).toThrow();
+    expect(() => fromRfc3339("2002-10-02T11:60:13Z")).toThrow();
+    expect(() => fromRfc3339("2002-10-02T11:12:13+24:00")).toThrow();
+    expect(() => fromRfc3339("2002-10-02T11:12:13+01:60")).toThrow();
   });
 
   it("encodes dates", () => {

--- a/packages/encoding/src/rfc3339.ts
+++ b/packages/encoding/src/rfc3339.ts
@@ -7,6 +7,25 @@ function padded(integer: number, length = 2): string {
   return integer.toString().padStart(length, "0");
 }
 
+function getLastDayOfMonth(year: number, month: number): number {
+  const date = new Date(0);
+  date.setUTCFullYear(year, month, 0);
+  date.setUTCHours(0, 0, 0, 0);
+  return date.getUTCDate();
+}
+
+function isValidDate(year: number, month: number, day: number): boolean {
+  return month >= 1 && month <= 12 && day >= 1 && day <= getLastDayOfMonth(year, month);
+}
+
+function isValidTime(hour: number, minute: number, second: number): boolean {
+  return hour <= 23 && minute <= 59 && second <= 59;
+}
+
+function isValidTimezoneOffset(hours: number, minutes: number): boolean {
+  return hours <= 23 && minutes <= 59;
+}
+
 export function fromRfc3339(str: string): Date {
   const matches = rfc3339Matcher.exec(str);
   if (!matches) {
@@ -38,9 +57,17 @@ export function fromRfc3339(str: string): Date {
     tzOffsetMinutes = +matches[8].substring(4, 6);
   }
 
+  if (
+    !isValidDate(year, month, day) ||
+    !isValidTime(hour, minute, second) ||
+    !isValidTimezoneOffset(tzOffsetHours, tzOffsetMinutes)
+  ) {
+    throw new Error("Date string is not in RFC3339 format");
+  }
+
   const tzOffset = tzOffsetSign * (tzOffsetHours * 60 + tzOffsetMinutes) * 60; // seconds
 
-  const date = new Date();
+  const date = new Date(0);
   date.setUTCFullYear(year, month - 1, day);
   date.setUTCHours(hour, minute, second, milliSeconds);
 


### PR DESCRIPTION
## Summary

This adds explicit range validation to `fromRfc3339` before constructing a `Date`.

Previously, inputs that matched the RFC3339-shaped regex but contained out-of-range values could be silently normalized by JavaScript `Date`, for example month `13`, February `30`, hour `24`, or timezone offset `+24:00`. Those inputs are now rejected with the existing RFC3339 format error.

The tests also cover a valid leap day to ensure valid calendar dates continue to parse correctly.

## Testing

- `git diff --check`
- Targeted local RFC3339 validation check covering valid leap-day/year cases and out-of-range components
