### PR TITLE
remove unused type casts from tests

### DIFF
--- a/packages/socket/src/queueingstreamingsocket.spec.ts
+++ b/packages/socket/src/queueingstreamingsocket.spec.ts
@@ -14,10 +14,9 @@ describe("QueueingStreamingSocket", () => {
 
   (enabled ? describe : xdescribe)("queueRequest", () => {
     it("can queue and process requests with a connection", async () => {
-      let done!: (() => void) & { fail: (e?: any) => void };
-      const ret = new Promise<void>((resolve, reject) => {
-        done = resolve as typeof done;
-        done.fail = reject;
+      let done!: () => void;
+      const ret = new Promise<void>((resolve) => {
+        done = resolve;
       });
       const socket = new QueueingStreamingSocket(socketServerUrl);
       const requests = ["request 1", "request 2", "request 3"] as const;
@@ -42,10 +41,9 @@ describe("QueueingStreamingSocket", () => {
     });
 
     it("can queue requests without a connection and process them later", async () => {
-      let done!: (() => void) & { fail: (e?: any) => void };
-      const ret = new Promise<void>((resolve, reject) => {
-        done = resolve as typeof done;
-        done.fail = reject;
+      let done!: () => void;
+      const ret = new Promise<void>((resolve) => {
+        done = resolve;
       });
       const socket = new QueueingStreamingSocket(socketServerUrl);
       const requests = ["request 1", "request 2", "request 3"] as const;
@@ -104,10 +102,9 @@ describe("QueueingStreamingSocket", () => {
     });
 
     it("can reconnect and process remaining queue", async () => {
-      let done!: (() => void) & { fail: (e?: any) => void };
-      const ret = new Promise<void>((resolve, reject) => {
-        done = resolve as typeof done;
-        done.fail = reject;
+      let done!: () => void;
+      const ret = new Promise<void>((resolve) => {
+        done = resolve;
       });
       const socket = new QueueingStreamingSocket(socketServerUrl);
       const requests = ["request 1", "request 2", "request 3"] as const;
@@ -136,10 +133,9 @@ describe("QueueingStreamingSocket", () => {
     });
 
     it("notifies on reconnection via a callback", async () => {
-      let done!: (() => void) & { fail: (e?: any) => void };
-      const ret = new Promise<void>((resolve, reject) => {
-        done = resolve as typeof done;
-        done.fail = reject;
+      let done!: () => void;
+      const ret = new Promise<void>((resolve) => {
+        done = resolve;
       });
       const socket = new QueueingStreamingSocket(socketServerUrl, undefined, done);
 

--- a/packages/stream/src/dropduplicates.spec.ts
+++ b/packages/stream/src/dropduplicates.spec.ts
@@ -9,10 +9,9 @@ describe("dropDuplicates", () => {
   });
 
   it("passes unique values", async () => {
-    let done!: (() => void) & { fail: (e?: any) => void };
-    const ret = new Promise<void>((resolve, reject) => {
-      done = resolve as typeof done;
-      done.fail = reject;
+    let done!: () => void;
+    const ret = new Promise<void>((resolve) => {
+      done = resolve;
     });
     const instream = Stream.fromArray([0, 1, 2, 3]);
     const operand = dropDuplicates<number>((value) => `${value}`);
@@ -30,10 +29,9 @@ describe("dropDuplicates", () => {
   });
 
   it("drops consecutive duplicates", async () => {
-    let done!: (() => void) & { fail: (e?: any) => void };
-    const ret = new Promise<void>((resolve, reject) => {
-      done = resolve as typeof done;
-      done.fail = reject;
+    let done!: () => void;
+    const ret = new Promise<void>((resolve) => {
+      done = resolve;
     });
     const instream = Stream.fromArray([1, 2, 2, 3, 3, 3, 4, 4, 4, 4]);
     const operand = dropDuplicates<number>((value) => `${value}`);
@@ -51,10 +49,9 @@ describe("dropDuplicates", () => {
   });
 
   it("drops non-consecutive duplicates", async () => {
-    let done!: (() => void) & { fail: (e?: any) => void };
-    const ret = new Promise<void>((resolve, reject) => {
-      done = resolve as typeof done;
-      done.fail = reject;
+    let done!: () => void;
+    const ret = new Promise<void>((resolve) => {
+      done = resolve;
     });
     const instream = Stream.fromArray([1, 2, 3, 4, 3, 2, 1]);
     const operand = dropDuplicates<number>((value) => `${value}`);
@@ -72,10 +69,9 @@ describe("dropDuplicates", () => {
   });
 
   it("uses value to key method for duplicate checks", async () => {
-    let done!: (() => void) & { fail: (e?: any) => void };
-    const ret = new Promise<void>((resolve, reject) => {
-      done = resolve as typeof done;
-      done.fail = reject;
+    let done!: () => void;
+    const ret = new Promise<void>((resolve) => {
+      done = resolve;
     });
     const instream = Stream.fromArray([1, 10, 100, 2000, 2, 27, 1337, 3.14, 33]);
     // use first character of native string representation
@@ -95,10 +91,9 @@ describe("dropDuplicates", () => {
   });
 
   it("works for empty string keys", async () => {
-    let done!: (() => void) & { fail: (e?: any) => void };
-    const ret = new Promise<void>((resolve, reject) => {
-      done = resolve as typeof done;
-      done.fail = reject;
+    let done!: () => void;
+    const ret = new Promise<void>((resolve) => {
+      done = resolve;
     });
     interface Name {
       readonly first: string;


### PR DESCRIPTION
These asynchronous tests never actually called the boilerplate function `done.fail()`.