### PR TITLE
correct changelog for 0.39 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,7 @@ and this project adheres to
 
 ### Changed
 
-- all: Drop support for Node.js < 22. Node.js 20 reached end-of-life on 2025-04
-  and the crypto stack (@noble/\*, @scure/bip39 v2) relies on APIs that only
-  ship in Node 22+. If you are still on an older Node, upgrade before taking
-  this release.
+- all: Drop support for Node.js < 22. Node.js 20 reached end-of-life on 2026-04.
 - @cosmjs/crypto: Upgrade dependencies @noble/ciphers, @noble/curves,
   @noble/hashes and @scure/bip39 to v2. These upgrades are otherwise transparent
   to users of the high-level `@cosmjs/crypto` API, but direct consumers of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,7 @@ and this project adheres to
 
 - all: Drop support for Node.js < 22. Node.js 20 reached end-of-life on 2026-04.
 - @cosmjs/crypto: Upgrade dependencies @noble/ciphers, @noble/curves,
-  @noble/hashes and @scure/bip39 to v2. These upgrades are otherwise transparent
-  to users of the high-level `@cosmjs/crypto` API, but direct consumers of the
-  underlying libraries should consult their respective migration notes.
-  ([#1935])
+  @noble/hashes and @scure/bip39 to v2. ([#1935])
 - @cosmjs/crypto: Use pure-JS implementation of Argon2id from @noble/hashes
   instead of the WASM-based `hash-wasm` implementation. This removes the
   `hash-wasm` runtime dependency. ([#1938])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ and this project adheres to
   ([#1935])
 - @cosmjs/crypto: Use pure-JS implementation of Argon2id from @noble/hashes
   instead of the WASM-based `hash-wasm` implementation. This removes the
-  `hash-wasm` runtime dependency and makes `Argon2id.execute` fully
-  synchronous-capable without requiring a WASM instantiation. ([#1938])
+  `hash-wasm` runtime dependency. ([#1938])
 - @cosmjs/amino, @cosmjs/proto-signing: Remove scream test around argon2 call in
   wallet serialization/deserialization which is not needed anymore after
   [#1938].


### PR DESCRIPTION
The new text appended to the first entry in the 0.39 changelog (generated by Cursor? ec55c660ad18cca4dec8d7ab637cce9c6b5588f7) is 100% wrong.

It lists the wrong EOL date, and it's hallucinating things not actually stated in https://github.com/cosmos/cosmjs/issues/1816#issuecomment-3699053793 without reading the context at #1862 which explains that the cause of incompatibility with Node 20 is Yarn. Users aren't generally affected, the dependencies don't require anything from Node 22+ - it's Yarn that requires 22+.

The other AI-generated text that got added looks more confusing than useful to consumers - `direct consumers of the underlying libraries should consult their respective migration notes`? Direct consumers with a direct dependency won't get bumped to a new major version just by upgrading. ```makes `Argon2id.execute` fully synchronous-capable```? Technically true, but it's still an [`async`](https://github.com/cosmos/cosmjs/pull/1939/changes#diff-fd3bac972fd0f079aadf86086281ec07dd2c6d3fae2f8a3fbe38f16f163287eaR32-R34) function, and has to remain async to eventually migrate to the WebCrypto implementation instead.