### PR TITLE
simplify beforeAll() in tests

### DIFF
--- a/packages/cosmwasm/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.spec.ts
@@ -385,9 +385,6 @@ interface HackatomInstance {
     let contract: HackatomInstance | undefined;
 
     beforeAll(async () => {
-      if (!wasmdEnabled) {
-        return;
-      }
       const wallet = await DirectSecp256k1HdWallet.fromMnemonic(alice.mnemonic, { prefix: wasmd.prefix });
       const client = await SigningCosmWasmClient.connectWithSigner(wasmd.endpoint, wallet);
       const { codeId } = await client.upload(alice.address0, getHackatom().data, defaultUploadFee);

--- a/packages/cosmwasm/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.spec.ts
@@ -385,21 +385,22 @@ interface HackatomInstance {
     let contract: HackatomInstance | undefined;
 
     beforeAll(async () => {
-      if (wasmdEnabled) {
-        const wallet = await DirectSecp256k1HdWallet.fromMnemonic(alice.mnemonic, { prefix: wasmd.prefix });
-        const client = await SigningCosmWasmClient.connectWithSigner(wasmd.endpoint, wallet);
-        const { codeId } = await client.upload(alice.address0, getHackatom().data, defaultUploadFee);
-        const instantiateMsg = { verifier: makeRandomAddress(), beneficiary: makeRandomAddress() };
-        const label = "a different hackatom";
-        const { contractAddress } = await client.instantiate(
-          alice.address0,
-          codeId,
-          instantiateMsg,
-          label,
-          defaultInstantiateFee,
-        );
-        contract = { instantiateMsg: instantiateMsg, address: contractAddress };
+      if (!wasmdEnabled) {
+        return;
       }
+      const wallet = await DirectSecp256k1HdWallet.fromMnemonic(alice.mnemonic, { prefix: wasmd.prefix });
+      const client = await SigningCosmWasmClient.connectWithSigner(wasmd.endpoint, wallet);
+      const { codeId } = await client.upload(alice.address0, getHackatom().data, defaultUploadFee);
+      const instantiateMsg = { verifier: makeRandomAddress(), beneficiary: makeRandomAddress() };
+      const label = "a different hackatom";
+      const { contractAddress } = await client.instantiate(
+        alice.address0,
+        codeId,
+        instantiateMsg,
+        label,
+        defaultInstantiateFee,
+      );
+      contract = { instantiateMsg: instantiateMsg, address: contractAddress };
     });
 
     it("works", async () => {

--- a/packages/ledger-amino/src/ledgersigner.spec.ts
+++ b/packages/ledger-amino/src/ledgersigner.spec.ts
@@ -49,20 +49,21 @@ async function createTransport(): Promise<Transport> {
   let transport: Transport;
 
   beforeAll(async () => {
-    if (simappEnabled) {
-      const wallet = await Secp256k1HdWallet.fromMnemonic(faucet.mnemonic);
-      const client = await SigningStargateClient.connectWithSigner(simapp.endpoint, wallet);
-      const amount = coins(226644, "ucosm");
-      const memo = "Ensure chain has my pubkey";
-      const sendResult = await client.sendTokens(
-        faucet.address,
-        defaultLedgerAddress,
-        amount,
-        defaultFee,
-        memo,
-      );
-      assertIsDeliverTxSuccessStargate(sendResult);
+    if (!simappEnabled) {
+      return;
     }
+    const wallet = await Secp256k1HdWallet.fromMnemonic(faucet.mnemonic);
+    const client = await SigningStargateClient.connectWithSigner(simapp.endpoint, wallet);
+    const amount = coins(226644, "ucosm");
+    const memo = "Ensure chain has my pubkey";
+    const sendResult = await client.sendTokens(
+      faucet.address,
+      defaultLedgerAddress,
+      amount,
+      defaultFee,
+      memo,
+    );
+    assertIsDeliverTxSuccessStargate(sendResult);
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
There's no need to enclose the entire body of these functions in a single if block.

One of these conditions is already guaranteed to be true.

https://github.com/cosmos/cosmjs/blob/ec55c660ad18cca4dec8d7ab637cce9c6b5588f7/packages/cosmwasm/src/cosmwasmclient.spec.ts#L41

Missed in #1839 and #1851