### PR TITLE
update Dockerfile to use python 3.14

### DIFF
--- a/scripts/httpserver/Dockerfile
+++ b/scripts/httpserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.14-alpine
 
 WORKDIR /usr/src/app
 

--- a/scripts/socketserver/Dockerfile
+++ b/scripts/socketserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.14-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Python 3.7 was EOL in 2020, and 3.9 was EOL in 2022.