### PR TITLE
delete redundant "types" field

### DIFF
--- a/packages/amino/package.json
+++ b/packages/amino/package.json
@@ -7,7 +7,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/cosmwasm-stargate/package.json
+++ b/packages/cosmwasm-stargate/package.json
@@ -7,7 +7,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/cosmwasm/package.json
+++ b/packages/cosmwasm/package.json
@@ -8,7 +8,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -8,7 +8,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/encoding/package.json
+++ b/packages/encoding/package.json
@@ -8,7 +8,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/faucet-client/package.json
+++ b/packages/faucet-client/package.json
@@ -8,7 +8,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/json-rpc/package.json
+++ b/packages/json-rpc/package.json
@@ -10,7 +10,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/ledger-amino/package.json
+++ b/packages/ledger-amino/package.json
@@ -8,7 +8,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -8,7 +8,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/proto-signing/package.json
+++ b/packages/proto-signing/package.json
@@ -8,7 +8,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/socket/package.json
+++ b/packages/socket/package.json
@@ -10,7 +10,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/stargate/package.json
+++ b/packages/stargate/package.json
@@ -7,7 +7,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -10,7 +10,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/tendermint-rpc/package.json
+++ b/packages/tendermint-rpc/package.json
@@ -10,7 +10,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,7 +8,6 @@
   ],
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "types": "build/index.d.ts",
   "exports": {
     "types": "./build/index.d.ts",
     "default": "./build/index.js"


### PR DESCRIPTION
This field does nothing for TypeScript since `exports.types` exists.

Followup to #1944 #1940