### PR TITLE
delete redundant 'no-dynamic-delete' lint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -143,7 +143,6 @@ export default [
         },
       ],
 
-      "@typescript-eslint/no-dynamic-delete": "warn",
       "@typescript-eslint/no-empty-object-type": "off",
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-misused-promises": "off",


### PR DESCRIPTION
[This lint](https://typescript-eslint.io/rules/no-dynamic-delete/) is already enabled by `strict-type-checked`, it doesn't need to be enabled twice.

Fix on #1767