### PR TITLE
feat(encoding): add bech32m address support

### DIFF
--- a/packages/encoding/src/bech32.spec.ts
+++ b/packages/encoding/src/bech32.spec.ts
@@ -49,6 +49,7 @@ describe("bech32", () => {
       expect(fromBech32("eth1n48g2mjh9ezz7zjtya37wtgg5r5emr0drkwlgw")).toEqual({
         prefix: "eth",
         data: ethAddressRaw,
+        encoding: "bech32",
       });
     });
 
@@ -58,6 +59,7 @@ describe("bech32", () => {
       expect(fromBech32("ETH1N48G2MJH9EZZ7ZJTYA37WTGG5R5EMR0DRKWLGW")).toEqual({
         prefix: "eth",
         data: ethAddressRaw,
+        encoding: "bech32",
       });
     });
 
@@ -132,6 +134,47 @@ describe("bech32", () => {
       expect(() => normalizeBech32("eth1n48g2mjh9Ezz7zjtya37wtgg5r5emr0drkwlgw")).toThrowError(
         /must be lowercase or uppercase/i,
       );
+    });
+  });
+
+  describe("bech32m variant", () => {
+    // Same data as the bech32 case above; only the checksum constant differs.
+    const ethBech32m = "eth1n48g2mjh9ezz7zjtya37wtgg5r5emr0dk27ndv";
+
+    it("toBech32 encodes bech32m when requested", () => {
+      expect(toBech32("eth", ethAddressRaw, undefined, "bech32m")).toEqual(ethBech32m);
+      // ... and differs from the default bech32 encoding of the same data
+      expect(toBech32("eth", ethAddressRaw)).not.toEqual(ethBech32m);
+    });
+
+    it("fromBech32 auto-detects the bech32m variant", () => {
+      expect(fromBech32(ethBech32m)).toEqual({
+        prefix: "eth",
+        data: ethAddressRaw,
+        encoding: "bech32m",
+      });
+    });
+
+    it("reports the bech32 variant for a bech32 address", () => {
+      expect(fromBech32("eth1n48g2mjh9ezz7zjtya37wtgg5r5emr0drkwlgw").encoding).toEqual("bech32");
+    });
+
+    it("round-trips bech32m data", () => {
+      const encoded = toBech32("juno", ethAddressRaw, undefined, "bech32m");
+      const { data, encoding } = fromBech32(encoded);
+      expect(encoding).toEqual("bech32m");
+      expect(data).toEqual(ethAddressRaw);
+    });
+
+    it("normalizeBech32 preserves the bech32m variant", () => {
+      // Must not silently re-encode a bech32m address as bech32, which would
+      // change the checksum and therefore the address.
+      expect(normalizeBech32(ethBech32m.toUpperCase())).toEqual(ethBech32m);
+    });
+
+    it("decodes a BIP350 test vector", () => {
+      // From https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki
+      expect(fromBech32("abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx").encoding).toEqual("bech32m");
     });
   });
 });

--- a/packages/encoding/src/bech32.ts
+++ b/packages/encoding/src/bech32.ts
@@ -1,9 +1,18 @@
-import { bech32 } from "@scure/base";
+import { bech32, bech32m } from "@scure/base";
 
 import { fixUint8Array } from "./uint8array";
 
-export function toBech32(prefix: string, data: Uint8Array, limit?: number): string {
-  const address = bech32.encode(prefix, bech32.toWords(data), limit);
+/** The two Bech32 checksum variants: BIP173 (bech32) and BIP350 (bech32m). */
+export type Bech32Encoding = "bech32" | "bech32m";
+
+export function toBech32(
+  prefix: string,
+  data: Uint8Array,
+  limit?: number,
+  encoding: Bech32Encoding = "bech32",
+): string {
+  const impl = encoding === "bech32m" ? bech32m : bech32;
+  const address = impl.encode(prefix, impl.toWords(data), limit);
   return address;
 }
 
@@ -14,25 +23,38 @@ function hasBech32Separator(input: string): input is `${string}1${string}` {
 export function fromBech32(
   address: string,
   limit = Infinity,
-): { readonly prefix: string; readonly data: Uint8Array<ArrayBuffer> } {
+): { readonly prefix: string; readonly data: Uint8Array<ArrayBuffer>; readonly encoding: Bech32Encoding } {
   // This extra check can be removed once
   // https://github.com/paulmillr/scure-base/pull/45 is merged and published.
   if (!hasBech32Separator(address)) throw new Error(`No bech32 separator found`);
 
-  const decodedAddress = bech32.decode(address, limit);
+  // The bech32 and bech32m checksums use different constants, so at most one of
+  // the two decodes a given address. Try bech32 (the common case for Cosmos
+  // accounts) first, then bech32m. `fromWords` is identical for both variants.
+  let decoded: { readonly prefix: string; readonly words: number[] };
+  let encoding: Bech32Encoding;
+  try {
+    decoded = bech32.decode(address, limit);
+    encoding = "bech32";
+  } catch {
+    decoded = bech32m.decode(address, limit);
+    encoding = "bech32m";
+  }
   return {
-    prefix: decodedAddress.prefix,
-    data: fixUint8Array(bech32.fromWords(decodedAddress.words)),
+    prefix: decoded.prefix,
+    data: fixUint8Array(bech32.fromWords(decoded.words)),
+    encoding,
   };
 }
 
 /**
- * Takes a bech32 address and returns a normalized (i.e. lower case) representation of it.
+ * Takes a bech32 or bech32m address and returns a normalized (i.e. lower case)
+ * representation of it, preserving the original checksum variant.
  *
  * The input is validated along the way, which makes this significantly safer than
  * using `address.toLowerCase()`.
  */
 export function normalizeBech32(address: string): string {
-  const { prefix, data } = fromBech32(address);
-  return toBech32(prefix, data);
+  const { prefix, data, encoding } = fromBech32(address);
+  return toBech32(prefix, data, undefined, encoding);
 }


### PR DESCRIPTION
closes #1802

## what

Adds bech32m (BIP350) address support to `@cosmjs/encoding`. Some chains use bech32m instead of bech32 (BIP173), and the package only handled bech32.

## how

`@scure/base` (already the dependency) exports both `bech32` and `bech32m`; the two differ only in the checksum constant, so at most one decodes a given address.

- `toBech32(prefix, data, limit?, encoding?)` gains an optional `encoding: "bech32" | "bech32m"`, defaulting to `"bech32"` (backward compatible).
- `fromBech32(address, limit?)` auto-detects the variant (try bech32, fall back to bech32m) and returns which `encoding` was used alongside `prefix`/`data`.
- `normalizeBech32` now preserves the detected variant, so a bech32m address is not silently re-encoded as bech32 (which would change its checksum, i.e. produce a different address).
- New exported type `Bech32Encoding`.

Note: `fromBech32`'s return gains an `encoding` field, so the two existing `toEqual({ prefix, data })` assertions were updated to include `encoding: "bech32"`.

## receipts

Verified against the exact pinned `@scure/base@2.0.0` and BIP350 test vectors.

```
$ yarn workspace @cosmjs/encoding run test-node
  3.4 bech32m variant
      ✓ toBech32 encodes bech32m when requested
      ✓ fromBech32 auto-detects the bech32m variant
      ✓ reports the bech32 variant for a bech32 address
      ✓ round-trips bech32m data
      ✓ normalizeBech32 preserves the bech32m variant
      ✓ decodes a BIP350 test vector
Executed 52 of 52 specs SUCCESS in 0.012 sec.

$ prettier --check   → All matched files use Prettier code style!
$ tsc                → emits clean
```

(Local build needs `--skipLibCheck` only to dodge a stray `~/node_modules/@types/pg` on this machine, unrelated to the change.)
