### PR TITLE
feat(stargate): implement authz Amino converters (MsgGrant, MsgRevoke)

### DIFF
--- a/packages/stargate/src/modules/authz/aminomessages.spec.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.spec.ts
@@ -108,6 +108,87 @@ describe("authz amino converters", () => {
         aminoTypes.toAmino({ typeUrl: "/cosmos.authz.v1beta1.MsgGrant", value: msg }),
       ).toThrowError(/Unsupported authorization type/i);
     });
+
+    it("omits allow_list for a SendAuthorization without an allow list (the common case)", () => {
+      // The SDK tags AllowList `json:",omitempty"`, so an empty allow list must
+      // produce no `allow_list` key at all - a stray `allow_list: []` would sign
+      // different bytes than the chain expects.
+      const msg: MsgGrant = {
+        granter: granter,
+        grantee: grantee,
+        grant: {
+          authorization: {
+            typeUrl: "/cosmos.bank.v1beta1.SendAuthorization",
+            value: SendAuthorization.encode(
+              SendAuthorization.fromPartial({
+                spendLimit: [{ denom: "ustake", amount: "1000000" }],
+                allowList: [],
+              }),
+            ).finish(),
+          },
+          expiration: undefined,
+        },
+      };
+      const aminoMsg = aminoTypes.toAmino({
+        typeUrl: "/cosmos.authz.v1beta1.MsgGrant",
+        value: msg,
+      }) as AminoMsgGrant;
+      expect(aminoMsg.value.grant.authorization.value).toEqual({
+        spend_limit: [{ denom: "ustake", amount: "1000000" }],
+      });
+      expect("allow_list" in aminoMsg.value.grant.authorization.value).toBe(false);
+      // Byte-level pin of the emitted amino JSON structure.
+      expect(JSON.stringify(aminoMsg)).toEqual(
+        JSON.stringify({
+          type: "cosmos-sdk/MsgGrant",
+          value: {
+            granter: granter,
+            grantee: grantee,
+            grant: {
+              authorization: {
+                type: "cosmos-sdk/SendAuthorization",
+                value: { spend_limit: [{ denom: "ustake", amount: "1000000" }] },
+              },
+            },
+          },
+        }),
+      );
+      const back = aminoTypes.fromAmino(aminoMsg);
+      expect(back).toEqual({ typeUrl: "/cosmos.authz.v1beta1.MsgGrant", value: MsgGrant.fromPartial(msg) });
+    });
+
+    it("renders a sub-second expiration as a trimmed RFC3339 fraction", () => {
+      const base: MsgGrant = {
+        granter: granter,
+        grantee: grantee,
+        grant: {
+          authorization: {
+            typeUrl: "/cosmos.authz.v1beta1.GenericAuthorization",
+            value: GenericAuthorization.encode(
+              GenericAuthorization.fromPartial({ msg: "/cosmos.bank.v1beta1.MsgSend" }),
+            ).finish(),
+          },
+          expiration: { seconds: BigInt(1596300), nanos: 123456789 },
+        },
+      };
+      const nanosMsg = aminoTypes.toAmino({
+        typeUrl: "/cosmos.authz.v1beta1.MsgGrant",
+        value: base,
+      }) as AminoMsgGrant;
+      // Full nanosecond precision, matching Go's RFC3339Nano.
+      expect(nanosMsg.value.grant.expiration).toEqual("1970-01-19T11:25:00.123456789Z");
+      // Trailing zeros are trimmed (5_000_000 ns -> .005Z), and it round-trips.
+      const trimMsg = aminoTypes.toAmino({
+        typeUrl: "/cosmos.authz.v1beta1.MsgGrant",
+        value: {
+          ...base,
+          grant: { ...base.grant, expiration: { seconds: BigInt(1596300), nanos: 5_000_000 } },
+        },
+      }) as AminoMsgGrant;
+      expect(trimMsg.value.grant.expiration).toEqual("1970-01-19T11:25:00.005Z");
+      const back = aminoTypes.fromAmino(nanosMsg);
+      expect(back).toEqual({ typeUrl: "/cosmos.authz.v1beta1.MsgGrant", value: MsgGrant.fromPartial(base) });
+    });
   });
 
   describe("MsgRevoke", () => {

--- a/packages/stargate/src/modules/authz/aminomessages.spec.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.spec.ts
@@ -1,0 +1,134 @@
+import { GenericAuthorization } from "cosmjs-types/cosmos/authz/v1beta1/authz";
+import { MsgGrant, MsgRevoke } from "cosmjs-types/cosmos/authz/v1beta1/tx";
+import { SendAuthorization } from "cosmjs-types/cosmos/bank/v1beta1/authz";
+import { Any } from "cosmjs-types/google/protobuf/any";
+
+import { AminoTypes } from "../../aminotypes";
+import { AminoMsgGrant, AminoMsgRevoke, createAuthzAminoConverters } from "./aminomessages";
+
+describe("authz amino converters", () => {
+  const aminoTypes = new AminoTypes(createAuthzAminoConverters());
+  const granter = "cosmos1p7v0km9ydt0y9nszlesjy8elzqc4n2v0w4xh2p";
+  const grantee = "cosmos10dyr9899g6t0pelew4nvf4j5c3jcgv0r73qga5";
+
+  describe("MsgGrant", () => {
+    it("works with a GenericAuthorization and no expiration", () => {
+      const msg: MsgGrant = {
+        granter: granter,
+        grantee: grantee,
+        grant: {
+          authorization: {
+            typeUrl: "/cosmos.authz.v1beta1.GenericAuthorization",
+            value: GenericAuthorization.encode(
+              GenericAuthorization.fromPartial({ msg: "/cosmos.bank.v1beta1.MsgSend" }),
+            ).finish(),
+          },
+          expiration: undefined,
+        },
+      };
+      const aminoMsg = aminoTypes.toAmino({ typeUrl: "/cosmos.authz.v1beta1.MsgGrant", value: msg });
+      const expected: AminoMsgGrant = {
+        type: "cosmos-sdk/MsgGrant",
+        value: {
+          granter: granter,
+          grantee: grantee,
+          grant: {
+            authorization: {
+              type: "cosmos-sdk/GenericAuthorization",
+              value: { msg: "/cosmos.bank.v1beta1.MsgSend" },
+            },
+          },
+        },
+      };
+      expect(aminoMsg).toEqual(expected);
+      // round trip
+      const back = aminoTypes.fromAmino(aminoMsg);
+      expect(back).toEqual({
+        typeUrl: "/cosmos.authz.v1beta1.MsgGrant",
+        value: MsgGrant.fromPartial(msg),
+      });
+    });
+
+    it("works with a SendAuthorization and an expiration", () => {
+      const msg: MsgGrant = {
+        granter: granter,
+        grantee: grantee,
+        grant: {
+          authorization: {
+            typeUrl: "/cosmos.bank.v1beta1.SendAuthorization",
+            value: SendAuthorization.encode(
+              SendAuthorization.fromPartial({
+                spendLimit: [{ denom: "ustake", amount: "1000000" }],
+                allowList: ["cosmos147auavf4tvghskslq2w65de0nh5dqdmljxc7kh"],
+              }),
+            ).finish(),
+          },
+          expiration: { seconds: BigInt(1596300), nanos: 0 },
+        },
+      };
+      const aminoMsg = aminoTypes.toAmino({ typeUrl: "/cosmos.authz.v1beta1.MsgGrant", value: msg });
+      const expected: AminoMsgGrant = {
+        type: "cosmos-sdk/MsgGrant",
+        value: {
+          granter: granter,
+          grantee: grantee,
+          grant: {
+            authorization: {
+              type: "cosmos-sdk/SendAuthorization",
+              value: {
+                spend_limit: [{ denom: "ustake", amount: "1000000" }],
+                allow_list: ["cosmos147auavf4tvghskslq2w65de0nh5dqdmljxc7kh"],
+              },
+            },
+            expiration: "1970-01-19T11:25:00Z",
+          },
+        },
+      };
+      expect(aminoMsg).toEqual(expected);
+      const back = aminoTypes.fromAmino(aminoMsg);
+      expect(back).toEqual({
+        typeUrl: "/cosmos.authz.v1beta1.MsgGrant",
+        value: MsgGrant.fromPartial(msg),
+      });
+    });
+
+    it("throws for an unsupported authorization type", () => {
+      const msg: MsgGrant = {
+        granter: granter,
+        grantee: grantee,
+        grant: {
+          authorization: Any.fromPartial({
+            typeUrl: "/cosmos.staking.v1beta1.StakeAuthorization",
+            value: new Uint8Array([1, 2, 3]),
+          }),
+          expiration: undefined,
+        },
+      };
+      expect(() =>
+        aminoTypes.toAmino({ typeUrl: "/cosmos.authz.v1beta1.MsgGrant", value: msg }),
+      ).toThrowError(/Unsupported authorization type/i);
+    });
+  });
+
+  describe("MsgRevoke", () => {
+    it("works", () => {
+      const msg: MsgRevoke = {
+        granter: granter,
+        grantee: grantee,
+        msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend",
+      };
+      const aminoMsg = aminoTypes.toAmino({ typeUrl: "/cosmos.authz.v1beta1.MsgRevoke", value: msg });
+      const expected: AminoMsgRevoke = {
+        type: "cosmos-sdk/MsgRevoke",
+        value: {
+          granter: granter,
+          grantee: grantee,
+          msg_type_url: "/cosmos.bank.v1beta1.MsgSend",
+        },
+      };
+      expect(aminoMsg).toEqual(expected);
+      const back = aminoTypes.fromAmino(aminoMsg);
+      expect(back).toEqual({ typeUrl: "/cosmos.authz.v1beta1.MsgRevoke", value: msg });
+    });
+  });
+});

--- a/packages/stargate/src/modules/authz/aminomessages.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.ts
@@ -1,13 +1,163 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { AminoMsg } from "@cosmjs/amino";
+import { assert, assertDefinedAndNotNull } from "@cosmjs/utils";
+import { GenericAuthorization, Grant } from "cosmjs-types/cosmos/authz/v1beta1/authz";
+import { MsgGrant, MsgRevoke } from "cosmjs-types/cosmos/authz/v1beta1/tx";
+import { SendAuthorization } from "cosmjs-types/cosmos/bank/v1beta1/authz";
+import { Any } from "cosmjs-types/google/protobuf/any";
+import { Timestamp } from "cosmjs-types/google/protobuf/timestamp";
+
 import { AminoConverters } from "../../aminotypes";
 
+/** An authorization rendered as an Amino `{ type, value }` envelope. */
+interface AminoAuthorization {
+  readonly type: string;
+  readonly value: Record<string, any>;
+}
+
+export interface AminoMsgGrant extends AminoMsg {
+  readonly type: "cosmos-sdk/MsgGrant";
+  readonly value: {
+    readonly granter: string;
+    readonly grantee: string;
+    readonly grant: {
+      readonly authorization: AminoAuthorization;
+      /** RFC3339 timestamp. Omitted when the grant does not expire. */
+      readonly expiration?: string;
+    };
+  };
+}
+
+export interface AminoMsgRevoke extends AminoMsg {
+  readonly type: "cosmos-sdk/MsgRevoke";
+  readonly value: {
+    readonly granter: string;
+    readonly grantee: string;
+    readonly msg_type_url: string;
+  };
+}
+
+// Grant.expiration is a protobuf Timestamp which the SDK renders as an RFC3339
+// string in Amino JSON. These helpers preserve nanosecond precision (they do
+// not round-trip through Date, which is millisecond-only).
+function expirationToAmino(timestamp: Timestamp): string {
+  const secondsPart = new Date(Number(timestamp.seconds) * 1000).toISOString().replace(/\.\d+Z$/, "Z");
+  if (timestamp.nanos === 0) return secondsPart;
+  const fraction = timestamp.nanos.toString().padStart(9, "0").replace(/0+$/, "");
+  return secondsPart.replace(/Z$/, `.${fraction}Z`);
+}
+
+function expirationFromAmino(rfc3339: string): Timestamp {
+  const fractionMatch = rfc3339.match(/\.(\d+)Z$/);
+  const nanos = fractionMatch ? Number(fractionMatch[1].padEnd(9, "0")) : 0;
+  const seconds = Math.floor(new Date(rfc3339).getTime() / 1000);
+  return { seconds: BigInt(seconds), nanos: nanos };
+}
+
+// The authorization inside a Grant is a protobuf `Any`. Following the same
+// fail-closed pattern as the gov module's proposal content, only a bounded set
+// of well-known authorizations is supported; anything else throws rather than
+// producing sign bytes that silently disagree with the chain.
+function authorizationToAmino(authorization: Any): AminoAuthorization {
+  switch (authorization.typeUrl) {
+    case "/cosmos.authz.v1beta1.GenericAuthorization": {
+      const auth = GenericAuthorization.decode(authorization.value);
+      return {
+        type: "cosmos-sdk/GenericAuthorization",
+        value: { msg: auth.msg },
+      };
+    }
+    case "/cosmos.bank.v1beta1.SendAuthorization": {
+      const auth = SendAuthorization.decode(authorization.value);
+      return {
+        type: "cosmos-sdk/SendAuthorization",
+        value: {
+          spend_limit: auth.spendLimit,
+          ...(auth.allowList.length > 0 ? { allow_list: auth.allowList } : {}),
+        },
+      };
+    }
+    default:
+      throw new Error(`Unsupported authorization type: '${authorization.typeUrl}'`);
+  }
+}
+
+function authorizationFromAmino(authorization: AminoAuthorization): Any {
+  switch (authorization.type) {
+    case "cosmos-sdk/GenericAuthorization": {
+      const { msg } = authorization.value;
+      assert(typeof msg === "string");
+      return Any.fromPartial({
+        typeUrl: "/cosmos.authz.v1beta1.GenericAuthorization",
+        value: GenericAuthorization.encode(GenericAuthorization.fromPartial({ msg: msg })).finish(),
+      });
+    }
+    case "cosmos-sdk/SendAuthorization": {
+      const { spend_limit, allow_list } = authorization.value;
+      return Any.fromPartial({
+        typeUrl: "/cosmos.bank.v1beta1.SendAuthorization",
+        value: SendAuthorization.encode(
+          SendAuthorization.fromPartial({
+            spendLimit: spend_limit,
+            allowList: allow_list ?? [],
+          }),
+        ).finish(),
+      });
+    }
+    default:
+      throw new Error(`Unsupported authorization type: '${authorization.type}'`);
+  }
+}
+
 export function createAuthzAminoConverters(): AminoConverters {
+  // For Cosmos SDK < 0.46 the Amino JSON codec was broken on chain and thus
+  // inaccessible (see https://github.com/cosmos/cosmjs/issues/1092). This is
+  // implemented for 0.46+ chains.
+  //
+  // MsgExec is intentionally left out: its `msgs` are arbitrary nested `Any`
+  // messages that would require recursively re-encoding through the full amino
+  // registry, and a partial implementation would silently produce wrong sign
+  // bytes. MsgGrant supports GenericAuthorization and SendAuthorization and
+  // throws on anything else (fail-closed).
   return {
-    // For Cosmos SDK < 0.46 the Amino JSON codec was broken on chain and thus inaccessible.
-    // Now this can be implemented for 0.46+ chains, see
-    // https://github.com/cosmos/cosmjs/issues/1092
-    //
-    // "/cosmos.authz.v1beta1.MsgGrant": IMPLEMENT ME,
-    // "/cosmos.authz.v1beta1.MsgExec": IMPLEMENT ME,
-    // "/cosmos.authz.v1beta1.MsgRevoke": IMPLEMENT ME,
+    "/cosmos.authz.v1beta1.MsgGrant": {
+      aminoType: "cosmos-sdk/MsgGrant",
+      toAmino: ({ granter, grantee, grant }: MsgGrant): AminoMsgGrant["value"] => {
+        assertDefinedAndNotNull(grant);
+        const authorization = grant.authorization;
+        assertDefinedAndNotNull(authorization);
+        return {
+          granter: granter,
+          grantee: grantee,
+          grant: {
+            authorization: authorizationToAmino(authorization),
+            ...(grant.expiration ? { expiration: expirationToAmino(grant.expiration) } : {}),
+          },
+        };
+      },
+      fromAmino: ({ granter, grantee, grant }: AminoMsgGrant["value"]): MsgGrant => {
+        return {
+          granter: granter,
+          grantee: grantee,
+          grant: Grant.fromPartial({
+            authorization: authorizationFromAmino(grant.authorization),
+            expiration: grant.expiration ? expirationFromAmino(grant.expiration) : undefined,
+          }),
+        };
+      },
+    },
+    "/cosmos.authz.v1beta1.MsgRevoke": {
+      aminoType: "cosmos-sdk/MsgRevoke",
+      toAmino: ({ granter, grantee, msgTypeUrl }: MsgRevoke): AminoMsgRevoke["value"] => ({
+        granter: granter,
+        grantee: grantee,
+        msg_type_url: msgTypeUrl,
+      }),
+      fromAmino: ({ granter, grantee, msg_type_url }: AminoMsgRevoke["value"]): MsgRevoke => ({
+        granter: granter,
+        grantee: grantee,
+        msgTypeUrl: msg_type_url,
+      }),
+    },
   };
 }

--- a/packages/stargate/src/modules/authz/aminomessages.ts
+++ b/packages/stargate/src/modules/authz/aminomessages.ts
@@ -94,6 +94,8 @@ function authorizationFromAmino(authorization: AminoAuthorization): Any {
     }
     case "cosmos-sdk/SendAuthorization": {
       const { spend_limit, allow_list } = authorization.value;
+      assert(Array.isArray(spend_limit));
+      if (allow_list !== undefined) assert(Array.isArray(allow_list));
       return Any.fromPartial({
         typeUrl: "/cosmos.bank.v1beta1.SendAuthorization",
         value: SendAuthorization.encode(
@@ -136,6 +138,7 @@ export function createAuthzAminoConverters(): AminoConverters {
         };
       },
       fromAmino: ({ granter, grantee, grant }: AminoMsgGrant["value"]): MsgGrant => {
+        assertDefinedAndNotNull(grant);
         return {
           granter: granter,
           grantee: grantee,


### PR DESCRIPTION
closes #1931

## what

Implements the authz Amino JSON converters. `createAuthzAminoConverters()` was an empty stub, so authz messages could not be signed with `SIGN_MODE_LEGACY_AMINO_JSON` (Ledger and other Amino-only signers).

Ships **MsgGrant** (with `GenericAuthorization` and `SendAuthorization`) and **MsgRevoke**.

## the hard part, and the scope decision

The difficulty is the nested `Any`: `MsgGrant.grant.authorization` is a protobuf `Any`, and `MsgExec.msgs` is `Any[]`. I mirrored the gov module's existing pattern for `MsgSubmitProposal.content` - a **fail-closed inline switch** over a bounded set of known types, throwing on anything else, so an unknown authorization can never produce sign bytes that silently disagree with the chain.

**MsgExec is intentionally deferred.** Its `msgs` are arbitrary nested messages that need recursive re-encoding through the *full* amino registry; a partial hand-rolled version fails open (wrong sign bytes for anything subtly off). Grant + Revoke with throw-on-unknown fail closed. This is called out in a code comment.

## correctness

Amino type strings (`cosmos-sdk/MsgGrant`, `cosmos-sdk/GenericAuthorization`, `cosmos-sdk/SendAuthorization`, `cosmos-sdk/MsgRevoke`) and the snake_case field maps were checked against the cosmos-sdk `x/authz` and `x/bank` legacy-amino codecs. `Grant.expiration` (a Timestamp) renders as an RFC3339 string preserving nanoseconds (avoiding the seconds-only truncation of the earlier abandoned attempt #1542).

## receipts

```
$ yarn workspace @cosmjs/stargate run test-node   (authz block)
  9 authz amino converters
    9.1 MsgGrant
      ✓ works with a GenericAuthorization and no expiration
      ✓ works with a SendAuthorization and an expiration
      ✓ throws for an unsupported authorization type
      ✓ omits allow_list for a SendAuthorization without an allow list (the common case)
      ✓ renders a sub-second expiration as a trimmed RFC3339 fraction
    9.2 MsgRevoke
      ✓ works
  (0 failed; the INCOMPLETE/PENDING count is the simapp integration suite, unrelated)

$ prettier --check   → All matched files use Prettier code style!
$ eslint --max-warnings 0   → clean
```

Tests round-trip each message through the real `AminoTypes` registry (`toAmino` then `fromAmino`). Golden Amino JSON was derived from the SDK's amino type strings + field maps; the local build needs `--skipLibCheck` only to dodge a stray `~/node_modules/@types/pg` on this machine, unrelated to the change.

Coverage was expanded after a security review focused on the SIGN_MODE_LEGACY_AMINO_JSON paths: the common SendAuthorization-without-`allow_list` case (asserting the key is omitted per the SDK's omitempty, with a byte-level pin) and sub-second expiration precision (nanosecond RFC3339 + trailing-zero trim). Input guards mirroring the gov precedent were added to `fromAmino`.

## follow-ups

MsgExec, and StakeAuthorization for MsgGrant, once a recursive-registry approach is agreed. A golden vector captured from the Go SDK's `x/authz` `LegacyAmino.MarshalJSON` would further harden the byte-level guarantees; the amino type strings and field names here were verified against the x/authz and x/bank legacy-amino codec registrations.
