### PR TITLE
feat(cosmwasm): surface contract set_data on ExecuteResult

### DIFF
--- a/packages/cosmwasm/src/signingcosmwasmclient.spec.ts
+++ b/packages/cosmwasm/src/signingcosmwasmclient.spec.ts
@@ -673,6 +673,8 @@ import {
       expect(result.height).toBeGreaterThan(0);
       expect(result.gasWanted).toBeGreaterThan(0);
       expect(result.gasUsed).toBeGreaterThan(0);
+      // One MsgExecuteContractResponse (and thus one `data` entry) per instruction.
+      expect(result.data.length).toEqual(1);
       const wasmEvent = result.events.find((e) => e.type === "wasm");
       assert(wasmEvent, "Event of type wasm expected");
       expect(wasmEvent.attributes).toContain({ key: "action", value: "release" });
@@ -794,6 +796,8 @@ import {
       const { events } = result;
       const wasmEvents = events.filter((e) => e.type == "wasm");
       expect(wasmEvents.length).toEqual(2);
+      // One `data` entry per instruction, in order.
+      expect(result.data.length).toEqual(2);
       const [wasmEvent1, wasmEvent2] = wasmEvents;
       expect(wasmEvent1.type).toEqual("wasm");
       expect(wasmEvent1.attributes).toContain({ key: "action", value: "release" });

--- a/packages/cosmwasm/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm/src/signingcosmwasmclient.ts
@@ -44,6 +44,7 @@ import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
 import {
   MsgClearAdmin,
   MsgExecuteContract,
+  MsgExecuteContractResponse,
   MsgInstantiateContract,
   MsgInstantiateContract2,
   MsgMigrateContract,
@@ -163,6 +164,12 @@ export interface ExecuteResult {
   /** Transaction hash (might be used as transaction ID). Guaranteed to be non-empty upper-case hex */
   readonly transactionHash: string;
   readonly events: readonly Event[];
+  /**
+   * The `data` bytes each executed contract returned via `Response::set_data`,
+   * one entry per instruction in the same order. Empty for chains running
+   * Cosmos SDK < 0.46, which do not expose message responses.
+   */
+  readonly data: readonly Uint8Array[];
   readonly gasWanted: bigint;
   readonly gasUsed: bigint;
 }
@@ -540,6 +547,11 @@ export class SigningCosmWasmClient extends CosmWasmClient {
       height: result.height,
       transactionHash: result.transactionHash,
       events: result.events,
+      // Each MsgExecuteContract produces a MsgExecuteContractResponse whose
+      // `data` field carries what the contract set via `Response::set_data`.
+      data: result.msgResponses.map(
+        (msgResponse) => MsgExecuteContractResponse.decode(msgResponse.value).data,
+      ),
       gasWanted: result.gasWanted,
       gasUsed: result.gasUsed,
     };


### PR DESCRIPTION
closes #1648

## what

`ExecuteResult` only surfaced events, so the binary data a contract returns via `Response::set_data(...)` was dropped. Adds a `data` field to `ExecuteResult`:

```ts
readonly data: readonly Uint8Array[]
```

one entry per instruction, decoded from the transaction's `MsgExecuteContractResponse` message responses in `executeMultiple` (which `execute` delegates to). Empty for chains on Cosmos SDK < 0.46, which do not expose message responses.

## receipts

The decode surfaces the bytes (standalone, against the repo's `cosmjs-types`):

```
MsgExecuteContractResponse.decode(encode({ data: 0xdeadbeef })).data === 0xdeadbeef   → true
```

- `tsc` typechecks the package (the `data` field and `MsgExecuteContractResponse.decode(...).data` compile).
- prettier + eslint clean.
- Extended the `execute` and `executeMultiple` specs to assert one `data` entry per instruction (these run against the wasmd integration harness in CI).

Follow-up worth considering: a test contract that actually calls `set_data` would let the integration suite assert the returned bytes end to end.
