### PR TITLE
docs: getContractInfo/getContractCodeHistory throw, not return null

### DIFF
--- a/packages/cosmwasm/src/modules/wasm/queries.ts
+++ b/packages/cosmwasm/src/modules/wasm/queries.ts
@@ -43,11 +43,11 @@ export interface WasmExtension {
       paginationKey?: Uint8Array,
     ) => Promise<QueryContractsByCreatorResponse>;
     /**
-     * Returns null when contract was not found at this address.
+     * Throws when no contract was found at this address.
      */
     readonly getContractInfo: (address: string) => Promise<QueryContractInfoResponse>;
     /**
-     * Returns null when contract history was not found for this address.
+     * Throws when no contract was found at this address.
      */
     readonly getContractCodeHistory: (
       address: string,


### PR DESCRIPTION
closes #1468

### what

`getContractInfo` and `getContractCodeHistory` are documented as "Returns null when contract was not found", but both have non-nullable return types (`Promise<QueryContractInfoResponse>` / `Promise<QueryContractHistoryResponse>`) and throw when the contract is not found - so the comments are wrong.

### how

Correct both doc comments to say they throw. Docs-only, no behavior change. (The file moved from `cosmwasm-stargate` to `cosmwasm` since #1468 was filed; the stale comments are still present at the new path.)
