### PR TITLE
fix(stargate): match feemarket GasPricesResponse entry to requested denom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- @cosmjs/stargate: `queryDynamicGasPrice` now selects the feemarket price entry
+  matching the requested denom instead of the last entry in the response
+  ([#1979])
+
 ## [0.39.0] - 2026-05-04
 
 ### Changed
@@ -51,6 +57,7 @@ and this project adheres to
   ([#1959])
 
 [#1935]: https://github.com/cosmos/cosmjs/pull/1935
+[#1979]: https://github.com/cosmos/cosmjs/pull/1979
 [#1938]: https://github.com/cosmos/cosmjs/issues/1938
 [#1944]: https://github.com/cosmos/cosmjs/pull/1944
 [#1956]: https://github.com/cosmos/cosmjs/pull/1956

--- a/packages/stargate/src/feemarket.spec.ts
+++ b/packages/stargate/src/feemarket.spec.ts
@@ -1,5 +1,6 @@
 import { fromUtf8 } from "@cosmjs/encoding";
 import { Decimal } from "@cosmjs/math";
+import { BinaryWriter } from "cosmjs-types/binary";
 
 import { checkDynamicGasPriceSupport, multiplyDecimalByNumber, queryDynamicGasPrice } from "./feemarket";
 
@@ -134,9 +135,10 @@ describe("Osmosis chain ID detection", () => {
     });
 
     it('treats "juno-1" as non-Osmosis chain', async () => {
+      // GasPricesResponse { prices: [DecCoin { denom: "ujuno", amount: "5300000000000000" }] }
       const feemarketResponse = new Uint8Array([
-        10, 25, 10, 5, 117, 97, 116, 111, 109, 18, 16, 53, 51, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
-        48, 48,
+        10, 25, 10, 5, 117, 106, 117, 110, 111, 18, 16, 53, 51, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+        48, 48, 48,
       ]);
       const queryClient = {
         queryAbci: async (path: string, _data: Uint8Array) => {
@@ -328,8 +330,10 @@ describe("queryDynamicGasPrice", () => {
 
   describe("Skip feemarket response parsing", () => {
     it("parses valid feemarket response", async () => {
+      // GasPricesResponse { prices: [DecCoin { denom: "uatom", amount: "25000000000000000" }] }
       const response = new Uint8Array([
-        10, 19, 18, 17, 50, 53, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+        10, 26, 10, 5, 117, 97, 116, 111, 109, 18, 17, 50, 53, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+        48, 48, 48,
       ]);
       const queryClient = createMockQueryClient(response);
 
@@ -350,20 +354,27 @@ describe("queryDynamicGasPrice", () => {
     });
 
     it("parses feemarket response with different decimal values", async () => {
+      // Each entry is GasPricesResponse { prices: [DecCoin { denom: "uatom", amount: <value> }] }
       const testCases = [
         {
           value: "0.025",
-          bytes: [10, 19, 18, 17, 50, 53, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48],
+          bytes: [
+            10, 26, 10, 5, 117, 97, 116, 111, 109, 18, 17, 50, 53, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+            48, 48, 48, 48,
+          ],
         },
         {
           value: "1.5",
-          bytes: [10, 21, 18, 19, 49, 53, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48],
+          bytes: [
+            10, 28, 10, 5, 117, 97, 116, 111, 109, 18, 19, 49, 53, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+            48, 48, 48, 48, 48, 48,
+          ],
         },
         {
           value: "100",
           bytes: [
-            10, 23, 18, 21, 49, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
-            48,
+            10, 30, 10, 5, 117, 97, 116, 111, 109, 18, 21, 49, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+            48, 48, 48, 48, 48, 48, 48, 48,
           ],
         },
       ];
@@ -382,7 +393,7 @@ describe("queryDynamicGasPrice", () => {
       const queryClient = createMockQueryClient(emptyResponse);
 
       await expectAsync(queryDynamicGasPrice(queryClient, "uatom", "cosmoshub-4")).toBeRejectedWithError(
-        /GasPricesResponse: amount not found/i,
+        /no price found for denom "uatom"/i,
       );
     });
 
@@ -397,6 +408,36 @@ describe("queryDynamicGasPrice", () => {
         /premature EOF|amount not found/i,
       );
     });
+
+    it("picks the entry matching the requested denom, not the last one in the list", async () => {
+      // GasPricesResponse { prices: [
+      //   DecCoin { denom: "uatom", amount: "5300000000000000" },   // 0.0053
+      //   DecCoin { denom: "uosmo", amount: "25000000000000000000" }, // 25.0
+      // ] }
+      const response = new Uint8Array([
+        10, 25, 10, 5, 117, 97, 116, 111, 109, 18, 16, 53, 51, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+        48, 48, 10, 29, 10, 5, 117, 111, 115, 109, 111, 18, 20, 50, 53, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+        48, 48, 48, 48, 48, 48, 48, 48, 48,
+      ]);
+      const queryClient = createMockQueryClient(response);
+
+      const result = await queryDynamicGasPrice(queryClient, "uatom", "cosmoshub-4");
+      expect(result.toString()).toBe("0.0053");
+    });
+
+    it("throws a denom-specific error when the requested denom is absent from the response", async () => {
+      // Same two-entry response as above (uatom, uosmo), but requesting a denom present in neither
+      const response = new Uint8Array([
+        10, 25, 10, 5, 117, 97, 116, 111, 109, 18, 16, 53, 51, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+        48, 48, 10, 29, 10, 5, 117, 111, 115, 109, 111, 18, 20, 50, 53, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+        48, 48, 48, 48, 48, 48, 48, 48, 48,
+      ]);
+      const queryClient = createMockQueryClient(response);
+
+      await expectAsync(queryDynamicGasPrice(queryClient, "ujuno", "cosmoshub-4")).toBeRejectedWithError(
+        /no price found for denom "ujuno"/i,
+      );
+    });
   });
 
   describe("request encoding", () => {
@@ -407,12 +448,22 @@ describe("queryDynamicGasPrice", () => {
         "ustake",
         "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       ];
-      const response = new Uint8Array([
-        10, 19, 18, 17, 50, 53, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
-      ]);
+
+      // Builds a GasPricesResponse { prices: [DecCoin { denom, amount: "25000000000000000" }] }
+      // matching the requested denom, since decode() now requires a denom match.
+      function encodeGasPricesResponseFixture(denom: string): Uint8Array {
+        const decCoinWriter = new BinaryWriter();
+        decCoinWriter.uint32(10).string(denom);
+        decCoinWriter.uint32(18).string("25000000000000000");
+
+        const responseWriter = new BinaryWriter();
+        responseWriter.uint32(10).bytes(decCoinWriter.finish());
+        return responseWriter.finish();
+      }
 
       for (const denom of denoms) {
         let capturedData: Uint8Array | null = null;
+        const response = encodeGasPricesResponseFixture(denom);
         const mockClient = {
           queryAbci: async (_path: string, data: Uint8Array) => {
             capturedData = data;

--- a/packages/stargate/src/feemarket.ts
+++ b/packages/stargate/src/feemarket.ts
@@ -118,7 +118,7 @@ export async function queryDynamicGasPrice(
       "/feemarket.feemarket.v1.Query/GasPrices",
       GasPricesRequest.encode({ denom: gasPriceDenom }),
     );
-    return GasPricesResponse.decode(response.value);
+    return GasPricesResponse.decode(response.value, gasPriceDenom);
   }
 }
 
@@ -198,17 +198,21 @@ const DecCoin = {
 /** Skip feemarket GasPricesResponse message */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const GasPricesResponse = {
-  decode(input: Uint8Array): Decimal {
+  decode(input: Uint8Array, expectedDenom: string): Decimal {
     const reader = new BinaryReader(input);
     let decCoin: DecCoin | undefined;
 
     while (reader.pos < reader.len) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        case 1:
-          // prices field (repeated DecCoin) - we only need the first one
-          decCoin = DecCoin.decode(reader.bytes());
+        case 1: {
+          // prices field (repeated DecCoin) - keep the one matching the requested denom
+          const candidate = DecCoin.decode(reader.bytes());
+          if (candidate.denom === expectedDenom) {
+            decCoin = candidate;
+          }
           break;
+        }
         default:
           reader.skipType(tag & 7);
           break;
@@ -216,7 +220,7 @@ const GasPricesResponse = {
     }
 
     if (!decCoin?.amount) {
-      throw new Error("GasPricesResponse: amount not found");
+      throw new Error(`GasPricesResponse: no price found for denom "${expectedDenom}"`);
     }
 
     return decodeCosmosSdkDecFromProto(decCoin.amount);


### PR DESCRIPTION
Found by inspection, no filed issue.

`packages/stargate/src/feemarket.ts`'s `GasPricesResponse.decode()` looped over the
repeated `prices` field and unconditionally kept the LAST entry seen -
contradicting its own comment ("we only need the first one") - and never checked
the decoded entry's denom against what was actually requested. A response with
multiple price entries silently returned whatever denom happened to be last,
potentially orders of magnitude off, feeding straight into fee calculation.

## This isn't a pathological edge case - it's the normal shape of the response

Checked the actual Skip feemarket proto
(`skip-mev/feemarket`, `proto/feemarket/feemarket/v1/query.proto`):
`GasPricesRequest` is an **empty message**. The `denom` this file encodes into it
is an unknown field the server silently ignores - `GasPrices` always returns
prices "in all available denoms". So a multi-entry response is the norm on any
multi-denom feemarket chain, not a rare/adversarial case, and client-side
filtering is the only place this can be corrected for this RPC. There's also no
fallback/default-denom semantic documented for this endpoint - if the requested
denom genuinely isn't in the response, throwing is the correct behavior, not a
silent substitution.

(The proto does expose a singular `GasPrice(GasPriceRequest{denom})` RPC that
filters server-side - swapping to that endpoint entirely is a reasonable
follow-up, but out of scope for this minimal fix on the existing code path.)

## Fix

Threaded the requested denom through `decode(expectedDenom)` and select only the
matching entry, throwing a denom-specific error if none matches. Updated the call
site in `queryDynamicGasPrice` (`gasPriceDenom` was already an in-scope
parameter).

## Blast radius

`queryDynamicGasPrice`'s only production caller,
`calculateFeeForTransaction` (`signingstargateclient.ts`), already wraps the call
in try/catch and falls back to `minGasPrice` on any failure (documented: "Falls
back to minGasPrice if the query fails"). So the worst case for a chain whose
configured `gasPriceDenom` never actually matches goes from "silently uses an
arbitrary wrong denom's price" to "uses the user's configured `minGasPrice`" -
exactly the already-documented fallback behavior, not a new failure mode.
`checkDynamicGasPriceSupport` and the Osmosis lane (a separate endpoint) are
untouched.

## Testing

Added 2 new cases in `feemarket.spec.ts`: selecting the matching-denom entry from
a multi-entry response (not the last one), and throwing the new denom-specific
error when the requested denom is absent. Also corrected 5 pre-existing test
fixtures that had denom-less or wrong-denom `DecCoin`s in their mock responses -
they only passed before by accident of the bug (the old code never checked denom
at all). Every corrected fixture keeps its original intended amount; only the
missing/wrong denom field was added, verified by hand-tracing the raw bytes.

Guard-validated: reverting the fix alone causes exactly the 2 new tests to fail
(one gets the wrong entry, one resolves instead of throwing) plus one pre-existing
error-message-regex test that needed updating for the new, more specific error
text - not a real regression. Restoring: 41/41 specs pass in `feemarket.spec.ts`.
Full `stargate` suite: 102/347 executed, 0 failures, 245 pending (pre-existing
network-gated specs, identical before/after). Lint clean.
