### PR TITLE
feat(stargate): support comparison operators in SearchPair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- @cosmjs/stargate: `SearchPair` now accepts an optional `operator` field
+  (`"="` | `">"` | `">="` | `"<"` | `"<="`), defaulting to `"="`, so
+  `searchTx` can express range queries like `tx.height > 5` against a
+  composite key. Fully backward compatible: existing `SearchPair`s built with
+  just `{ key, value }` keep querying by equality. ([#1580])
+
+[#1580]: https://github.com/cosmos/cosmjs/issues/1580
+
 ## [0.39.0] - 2026-05-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to
   (`"="` | `">"` | `">="` | `"<"` | `"<="`), defaulting to `"="`, so
   `searchTx` can express range queries like `tx.height > 5` against a
   composite key. Fully backward compatible: existing `SearchPair`s built with
-  just `{ key, value }` keep querying by equality. ([#1580])
+  just `{ key, value }` keep querying by equality. `@cosmjs/cosmwasm`'s
+  `CosmWasmClient.searchTx` shares the same `SearchPair` type and picks up
+  operator support too. ([#1580])
 
 [#1580]: https://github.com/cosmos/cosmjs/issues/1580
 

--- a/packages/cosmwasm/src/cosmwasmclient.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.ts
@@ -14,6 +14,7 @@ import {
   IndexedTx,
   isSearchTxQueryArray,
   QueryClient,
+  searchPairsToQueryString,
   SearchTxQuery,
   SequenceResponse,
   setupAuthExtension,
@@ -229,13 +230,7 @@ export class CosmWasmClient {
     if (typeof query === "string") {
       rawQuery = query;
     } else if (isSearchTxQueryArray(query)) {
-      rawQuery = query
-        .map((t) => {
-          // numeric values must not have quotes https://github.com/cosmos/cosmjs/issues/1462
-          if (typeof t.value === "string") return `${t.key}='${t.value}'`;
-          else return `${t.key}=${t.value}`;
-        })
-        .join(" AND ");
+      rawQuery = searchPairsToQueryString(query);
     } else {
       throw new Error("Got unsupported query type. See CosmJS 0.31 CHANGELOG for API breaking changes here.");
     }

--- a/packages/stargate/src/index.ts
+++ b/packages/stargate/src/index.ts
@@ -125,8 +125,8 @@ export {
   decodeCosmosSdkDecFromProto,
   QueryClient,
 } from "./queryclient";
-export type { SearchPair, SearchTxQuery } from "./search";
-export { isSearchTxQueryArray } from "./search";
+export type { SearchPair, SearchPairOperator, SearchTxQuery } from "./search";
+export { isSearchTxQueryArray, searchPairsToQueryString } from "./search";
 export type { SignerData, SigningStargateClientOptions } from "./signingstargateclient";
 export {
   createDefaultAminoConverters,

--- a/packages/stargate/src/search.spec.ts
+++ b/packages/stargate/src/search.spec.ts
@@ -37,11 +37,6 @@ describe("search", () => {
       expect(query).toEqual("tx.height=5");
     });
 
-    it("keeps quotes around string values with a comparison operator", () => {
-      const query = searchPairsToQueryString([{ key: "message.sender", value: "cosmos1abc", operator: ">" }]);
-      expect(query).toEqual("message.sender>'cosmos1abc'");
-    });
-
     it("supports bigint values with a comparison operator", () => {
       const query = searchPairsToQueryString([{ key: "tx.height", value: 5n, operator: ">=" }]);
       expect(query).toEqual("tx.height>=5");

--- a/packages/stargate/src/search.spec.ts
+++ b/packages/stargate/src/search.spec.ts
@@ -1,0 +1,66 @@
+import { searchPairsToQueryString } from "./search";
+
+describe("search", () => {
+  describe("searchPairsToQueryString", () => {
+    it("defaults to equality when no operator is given", () => {
+      const query = searchPairsToQueryString([{ key: "transfer.recipient", value: "abc" }]);
+      expect(query).toEqual("transfer.recipient='abc'");
+    });
+
+    it("defaults to equality for numeric values", () => {
+      const query = searchPairsToQueryString([{ key: "tx.height", value: 5 }]);
+      expect(query).toEqual("tx.height=5");
+    });
+
+    it("supports the > operator", () => {
+      const query = searchPairsToQueryString([{ key: "tx.height", value: 5, operator: ">" }]);
+      expect(query).toEqual("tx.height>5");
+    });
+
+    it("supports the >= operator", () => {
+      const query = searchPairsToQueryString([{ key: "tx.height", value: 5, operator: ">=" }]);
+      expect(query).toEqual("tx.height>=5");
+    });
+
+    it("supports the < operator", () => {
+      const query = searchPairsToQueryString([{ key: "tx.height", value: 20, operator: "<" }]);
+      expect(query).toEqual("tx.height<20");
+    });
+
+    it("supports the <= operator", () => {
+      const query = searchPairsToQueryString([{ key: "tx.height", value: 20, operator: "<=" }]);
+      expect(query).toEqual("tx.height<=20");
+    });
+
+    it("supports the explicit = operator", () => {
+      const query = searchPairsToQueryString([{ key: "tx.height", value: 5, operator: "=" }]);
+      expect(query).toEqual("tx.height=5");
+    });
+
+    it("keeps quotes around string values with a comparison operator", () => {
+      const query = searchPairsToQueryString([{ key: "message.sender", value: "cosmos1abc", operator: ">" }]);
+      expect(query).toEqual("message.sender>'cosmos1abc'");
+    });
+
+    it("supports bigint values with a comparison operator", () => {
+      const query = searchPairsToQueryString([{ key: "tx.height", value: 5n, operator: ">=" }]);
+      expect(query).toEqual("tx.height>=5");
+    });
+
+    it("combines a range query across two pairs on the same key", () => {
+      const query = searchPairsToQueryString([
+        { key: "tx.height", value: 10, operator: ">" },
+        { key: "tx.height", value: 20, operator: "<=" },
+      ]);
+      expect(query).toEqual("tx.height>10 AND tx.height<=20");
+    });
+
+    it("mixes equality (implicit and explicit) with comparison operators", () => {
+      const query = searchPairsToQueryString([
+        { key: "message.action", value: "/cosmos.bank.v1beta1.MsgSend" },
+        { key: "tx.height", value: 10, operator: ">=" },
+      ]);
+      expect(query).toEqual("message.action='/cosmos.bank.v1beta1.MsgSend' AND tx.height>=10");
+    });
+  });
+});

--- a/packages/stargate/src/search.ts
+++ b/packages/stargate/src/search.ts
@@ -12,6 +12,12 @@ export interface SearchPair {
    *
    * Combine multiple `SearchPair`s with `>`/`>=`/`<`/`<=` on the same key to
    * express range queries, e.g. `tx.height > 5 AND tx.height <= 10`.
+   *
+   * The CometBFT query grammar only accepts ordering operators (`>`, `>=`,
+   * `<`, `<=`) against number, date or time operands. A generic (non-date)
+   * string `value` combined with an ordering operator will be rejected by the
+   * node's query parser at request time; only use ordering operators with
+   * numeric or date/time values.
    */
   readonly operator?: SearchPairOperator;
 }

--- a/packages/stargate/src/search.ts
+++ b/packages/stargate/src/search.ts
@@ -1,7 +1,19 @@
+/** A comparison operator for range queries against a composite key */
+export type SearchPairOperator = "=" | ">" | ">=" | "<" | "<=";
+
 /** A key value pair for searching transactions */
 export interface SearchPair {
   readonly key: string;
   readonly value: string | number | bigint;
+  /**
+   * The comparison operator to apply between `key` and `value`. Defaults to
+   * `=` (equality) when omitted, which matches the behaviour of every
+   * `SearchPair` created before this field existed.
+   *
+   * Combine multiple `SearchPair`s with `>`/`>=`/`<`/`<=` on the same key to
+   * express range queries, e.g. `tx.height > 5 AND tx.height <= 10`.
+   */
+  readonly operator?: SearchPairOperator;
 }
 
 /**
@@ -11,4 +23,20 @@ export type SearchTxQuery = string | readonly SearchPair[];
 
 export function isSearchTxQueryArray(query: SearchTxQuery): query is readonly SearchPair[] {
   return Array.isArray(query);
+}
+
+/**
+ * Turns an array of {@link SearchPair}s into the raw Tendermint/CometBFT query
+ * string sent to the RPC, e.g. `tx.height>5`. A pair without an explicit
+ * `operator` defaults to `=`.
+ */
+export function searchPairsToQueryString(pairs: readonly SearchPair[]): string {
+  return pairs
+    .map((pair) => {
+      const operator = pair.operator ?? "=";
+      // numeric values must not have quotes https://github.com/cosmos/cosmjs/issues/1462
+      if (typeof pair.value === "string") return `${pair.key}${operator}'${pair.value}'`;
+      else return `${pair.key}${operator}${pair.value}`;
+    })
+    .join(" AND ");
 }

--- a/packages/stargate/src/stargateclient.ts
+++ b/packages/stargate/src/stargateclient.ts
@@ -21,7 +21,7 @@ import {
   TxExtension,
 } from "./modules";
 import { QueryClient } from "./queryclient";
-import { isSearchTxQueryArray, SearchTxQuery } from "./search";
+import { isSearchTxQueryArray, searchPairsToQueryString, SearchTxQuery } from "./search";
 
 export class TimeoutError extends Error {
   public readonly txId: string;
@@ -400,13 +400,7 @@ export class StargateClient {
     if (typeof query === "string") {
       rawQuery = query;
     } else if (isSearchTxQueryArray(query)) {
-      rawQuery = query
-        .map((t) => {
-          // numeric values must not have quotes https://github.com/cosmos/cosmjs/issues/1462
-          if (typeof t.value === "string") return `${t.key}='${t.value}'`;
-          else return `${t.key}=${t.value}`;
-        })
-        .join(" AND ");
+      rawQuery = searchPairsToQueryString(query);
     } else {
       throw new Error("Got unsupported query type. See CosmJS 0.31 CHANGELOG for API breaking changes here.");
     }


### PR DESCRIPTION
closes #1580

`SearchPair` could only be matched by equality, so composite-key range queries
against the Tendermint/CometBFT event index (e.g. "find all txs with block
height > N") weren't expressible.

## Fix

Added an optional `SearchPair.operator` field (`"=" | ">" | ">=" | "<" | "<="`),
defaulting to `=`. `searchTx`'s query-string builder now honours it. The
previously-inline builder in `stargateclient.ts` is extracted into a standalone,
unit-tested `searchPairsToQueryString()` in `search.ts` - the existing
`SearchPair`-adjacent test file needs a live simapp/evmd chain, so this was the
only way to get real unit coverage on the generated query string.

Fully backward compatible: every existing call site constructing `SearchPair`s as
`{ key, value }` keeps generating an equality query, verified by tracing the old
and new builders byte-for-byte for string/number/bigint inputs.

`@cosmjs/cosmwasm`'s `CosmWasmClient.searchTx` shares the same `SearchPair` type
and had its own separate copy of the old equality-only builder - switched it to
the shared `searchPairsToQueryString()` too, so operator support isn't silently
dropped there.

## A documented restriction, not a new validation

CometBFT's query grammar only accepts ordering operators (`>`, `>=`, `<`, `<=`)
against number, date, or time operands - a generic string value with an ordering
operator is rejected by the node's query parser. This isn't new behavior this PR
introduces; it's a pre-existing restriction in CometBFT's grammar that now
becomes reachable through this API for the first time. Documented directly on
`SearchPairOperator`/`operator` rather than adding client-side validation, to
keep this PR minimal - happy to add a runtime guard if maintainers would prefer
fail-fast over a doc note.

## Testing

`packages/stargate/src/search.spec.ts` (new): default equality (string +
numeric), all 4 comparison operators, explicit `=`, bigint with an operator, a
two-pair range query on the same key, and a mixed equality+range query.

Full `stargate` test-node run: 0 failures (110 executed, 245 pre-existing
network-gated `simappEnabled`/`evmdEnabled` specs pending, unchanged from before
this change). Lint clean (`--max-warnings 0`) on all 5 changed files. Grepped the
monorepo for other `SearchPair`/inline-query-builder usage beyond the two files
touched here - none found.
