### PR TITLE
feat(stargate): add simulate() to base StargateClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- @cosmjs/stargate: Add `simulate()` to the base `StargateClient`, deriving the
+  pubkey from the chain via `getAccount()` instead of a signer, plus a
+  `registry` option on `StargateClientOptions`. ([#1568])
+
+[#1568]: https://github.com/cosmos/cosmjs/issues/1568
+
 ## [0.39.0] - 2026-05-04
 
 ### Changed

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -188,7 +188,7 @@ export class SigningStargateClient extends StargateClient {
     this.gasPrice = options.gasPrice;
   }
 
-  public async simulate(
+  public override async simulate(
     signerAddress: string,
     messages: readonly EncodeObject[],
     memo: string | undefined,

--- a/packages/stargate/src/stargateclient.spec.ts
+++ b/packages/stargate/src/stargateclient.spec.ts
@@ -191,6 +191,77 @@ describe("isDeliverTxSuccess", () => {
     });
   });
 
+  describe("simulate", () => {
+    it("works without a signer for an account with a known pubkey", async () => {
+      const client = await StargateClient.connect(simapp.tendermintUrlHttp);
+
+      const gasUsed = await client.simulate(
+        validator.delegatorAddress,
+        [
+          {
+            typeUrl: "/cosmos.bank.v1beta1.MsgSend",
+            value: {
+              fromAddress: validator.delegatorAddress,
+              toAddress: makeRandomAddress(),
+              amount: coins(1234567, simapp.denomFee),
+            },
+          },
+        ],
+        "simulate without a signer",
+      );
+
+      expect(gasUsed).toBeGreaterThan(0);
+
+      client.disconnect();
+    });
+
+    it("rejects for an account without a pubkey on chain", async () => {
+      const client = await StargateClient.connect(simapp.tendermintUrlHttp);
+
+      await expectAsync(
+        client.simulate(
+          unused.address,
+          [
+            {
+              typeUrl: "/cosmos.bank.v1beta1.MsgSend",
+              value: {
+                fromAddress: unused.address,
+                toAddress: makeRandomAddress(),
+                amount: coins(1234567, simapp.denomFee),
+              },
+            },
+          ],
+          undefined,
+        ),
+      ).toBeRejectedWithError(/has no pubkey on chain yet/i);
+
+      client.disconnect();
+    });
+
+    it("rejects for non-existent address", async () => {
+      const client = await StargateClient.connect(simapp.tendermintUrlHttp);
+
+      await expectAsync(
+        client.simulate(
+          nonExistentAddress,
+          [
+            {
+              typeUrl: "/cosmos.bank.v1beta1.MsgSend",
+              value: {
+                fromAddress: nonExistentAddress,
+                toAddress: makeRandomAddress(),
+                amount: coins(1234567, simapp.denomFee),
+              },
+            },
+          ],
+          undefined,
+        ),
+      ).toBeRejectedWithError(/account '([a-z0-9]{10,90})' does not exist on chain/i);
+
+      client.disconnect();
+    });
+  });
+
   describe("getBlock", () => {
     it("works for latest block", async () => {
       const client = await StargateClient.connect(simapp.tendermintUrlHttp);

--- a/packages/stargate/src/stargateclient.ts
+++ b/packages/stargate/src/stargateclient.ts
@@ -1,8 +1,9 @@
 import { addCoins } from "@cosmjs/amino";
 import { fixUint8Array, toHex } from "@cosmjs/encoding";
 import { Uint53 } from "@cosmjs/math";
+import { EncodeObject, Registry } from "@cosmjs/proto-signing";
 import { CometClient, connectComet, HttpEndpoint, toRfc3339WithNanoseconds } from "@cosmjs/tendermint-rpc";
-import { assert, sleep } from "@cosmjs/utils";
+import { assert, assertDefined, sleep } from "@cosmjs/utils";
 import { MsgData, TxMsgData } from "cosmjs-types/cosmos/base/abci/v1beta1/abci";
 import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
 import { QueryDelegatorDelegationsResponse } from "cosmjs-types/cosmos/staking/v1beta1/query";
@@ -200,6 +201,15 @@ export interface PrivateStargateClient {
 
 export interface StargateClientOptions {
   readonly accountParser?: AccountParser;
+  /**
+   * The registry used to encode messages passed to {@link StargateClient.simulate}.
+   *
+   * Defaults to a plain `Registry` (which only knows `Coin` and `MsgSend`). If you want to
+   * simulate other message types, pass a `Registry` that has those types registered, e.g.
+   * `new Registry(defaultRegistryTypes)` from `SigningStargateClient`, extended with your own
+   * custom types if needed.
+   */
+  readonly registry?: Registry;
 }
 
 export class StargateClient {
@@ -209,6 +219,7 @@ export class StargateClient {
     | undefined;
   private chainId: string | undefined;
   private readonly accountParser: AccountParser;
+  private readonly messageRegistry: Registry;
 
   /**
    * Creates an instance by connecting to the given CometBFT RPC endpoint.
@@ -244,8 +255,9 @@ export class StargateClient {
         setupTxExtension,
       );
     }
-    const { accountParser = accountFromAny } = options;
+    const { accountParser = accountFromAny, registry = new Registry() } = options;
     this.accountParser = accountParser;
+    this.messageRegistry = registry;
   }
 
   protected getCometClient(): CometClient | undefined {
@@ -316,6 +328,47 @@ export class StargateClient {
       accountNumber: account.accountNumber,
       sequence: account.sequence,
     };
+  }
+
+  /**
+   * Simulates the given messages and returns the estimated gas usage, without requiring a
+   * signer. This is useful for read-only gas estimation / fee simulation tooling that knows an
+   * account's address but does not have signing access to it.
+   *
+   * Since there is no signer to derive a pubkey from, the account's pubkey is looked up on
+   * chain instead (via {@link StargateClient.getAccount}). This means the account must already
+   * have a pubkey revealed on chain, i.e. it must have broadcast at least one transaction
+   * before. Use `SigningStargateClient.simulate` instead if you have signer access and the
+   * account's pubkey is not yet known to the chain.
+   *
+   * To simulate messages other than `MsgSend`, construct this client with a `registry` option
+   * (see {@link StargateClientOptions.registry}) that has those message types registered.
+   */
+  public async simulate(
+    signerAddress: string,
+    messages: readonly EncodeObject[],
+    memo: string | undefined,
+  ): Promise<number> {
+    const anyMsgs = messages.map((m) => this.messageRegistry.encodeAsAny(m));
+    const account = await this.getAccount(signerAddress);
+    if (!account) {
+      throw new Error(
+        `Account '${signerAddress}' does not exist on chain. Send some tokens there before trying to simulate.`,
+      );
+    }
+    if (!account.pubkey) {
+      throw new Error(
+        `Account '${signerAddress}' has no pubkey on chain yet. It must broadcast at least one transaction before it can be used to simulate without a signer.`,
+      );
+    }
+    const { gasInfo } = await this.forceGetQueryClient().tx.simulate(
+      anyMsgs,
+      memo,
+      account.pubkey,
+      account.sequence,
+    );
+    assertDefined(gasInfo);
+    return Uint53.fromString(gasInfo.gasUsed.toString()).toNumber();
   }
 
   public async getBlock(height?: number): Promise<Block> {


### PR DESCRIPTION
closes #1568

`simulate()` only existed on `SigningStargateClient`, which requires a full
signer. This adds the same capability to the base, signer-less `StargateClient` -
useful for read-only gas estimation / fee simulation tooling that has chain
access but not private key access.

## Where the pubkey comes from

`SigningStargateClient.simulate()` derives the pubkey from the `OfflineSigner`'s
accounts. Without a signer, the base client derives it instead from
`getAccount(signerAddress)`, which already returns `Account.pubkey: Pubkey |
null` via `accountFromAny`/`decodeOptionalPubkey`. If the account doesn't exist,
or exists but has never broadcast a tx (pubkey still null on-chain), `simulate()`
throws a descriptive error rather than guessing.

This path is actually slightly more general than the signing client's: it
preserves whatever pubkey type URL the chain returns (secp256k1, ethsecp256k1,
ed25519, ...), where `SigningStargateClient.simulate()` hardcodes
`encodeSecp256k1Pubkey` and would mangle an eth_secp256k1 signer.

**Known gap, not addressed here**: if the caller has the pubkey out-of-band
(e.g. a hex-encoded pubkey for an account that's never broadcast) but the
address alone can't resolve one on-chain, this can't simulate for them. An
optional `pubkey?: Pubkey` parameter falling back to the chain lookup would
cover that case - deliberately left out to keep the signature identical to
`SigningStargateClient`'s override, but happy to add it if useful.

## Message registry

`StargateClientOptions` gets a new optional `registry?: Registry` (defaults to
a bare `new Registry()`, which only knows `Coin`/`MsgSend`). This is
asymmetric with `SigningStargateClient`, which defaults to `Registry(defaultRegistryTypes)`
- `defaultRegistryTypes` lives in `signingstargateclient.ts`, which imports
`stargateclient.ts`, so defaulting to the fuller set in the base would need a
circular import or moving that constant. Kept the narrower default rather than
restructuring the module graph for this. An unregistered message type fails
loud (`Unregistered type url: X`) before any network call, so the narrower
default errs safely - callers who want more message types just pass their own
`Registry`.

## Testing

3 new tests in `stargateclient.spec.ts` (happy path, pubkey-null rejection,
nonexistent-account rejection), following the file's existing fixtures and
`simappEnabled` gating convention. **Honest disclosure**: I couldn't run these
against a live chain locally - Docker was stuck on my machine (`docker info`
hangs). What I verified instead: the code builds and typechecks cleanly, the
happy-path test's preconditions are already pinned by existing green tests in
this same file (`getAccount(validator.delegatorAddress)` returning a non-null
pubkey) and in `auth/queries.spec.ts` at the proto layer, and the rejection
tests exercise the new code's own thrown errors before any chain call - those
don't need a live chain to be meaningful. The happy-path Simulate RPC itself
will get its first real run in CI's simapp job.

Also required an `override` modifier on `SigningStargateClient.simulate()`
(mechanical, no logic change - `noImplicitOverride` requires it once the base
class declares the method) and renamed the base class's private `registry`
field to `messageRegistry` (the public option name stays `registry`) to avoid
colliding with `SigningStargateClient`'s own public `registry` field.
